### PR TITLE
Add Limit test to document how the "limit" parameter is supposed to work

### DIFF
--- a/.github/workflows/scala-it.yml
+++ b/.github/workflows/scala-it.yml
@@ -17,5 +17,5 @@ jobs:
       - name: Run Integration Test
         env:
           CAM_KP_LOG_LEVEL: "INFO"
-          SPARQL_ENDPOINT: "https://cam-kp-sparql-dev.apps.renci.org/sparql"
+          SPARQL_ENDPOINT: "https://cam-kp-sparql.apps.renci.org/sparql"
         run: sbt "it:testOnly *ProdQueryServiceTest"

--- a/.github/workflows/scala-it.yml
+++ b/.github/workflows/scala-it.yml
@@ -17,5 +17,5 @@ jobs:
       - name: Run Integration Test
         env:
           CAM_KP_LOG_LEVEL: "INFO"
-          SPARQL_ENDPOINT: "https://cam-kp-sparql-dev.apps.renci.org/blazegraph/sparql"
+          SPARQL_ENDPOINT: "https://cam-kp-sparql-dev.apps.renci.org/sparql"
         run: sbt "it:testOnly *ProdQueryServiceTest"

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -18,5 +18,5 @@ jobs:
     - name: Run tests
       env:
         CAM_KP_LOG_LEVEL: "INFO"
-        SPARQL_ENDPOINT: "https://cam-kp-sparql-dev.apps.renci.org/blazegraph/sparql"
+        SPARQL_ENDPOINT: "https://cam-kp-sparql-dev.apps.renci.org/sparql"
       run: sbt test

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -18,5 +18,5 @@ jobs:
     - name: Run tests
       env:
         CAM_KP_LOG_LEVEL: "INFO"
-        SPARQL_ENDPOINT: "https://cam-kp-sparql-dev.apps.renci.org/sparql"
+        SPARQL_ENDPOINT: "https://cam-kp-sparql.apps.renci.org/sparql"
       run: sbt test

--- a/src/it/scala/org/renci/cam/it/QueryServiceTest.scala
+++ b/src/it/scala/org/renci/cam/it/QueryServiceTest.scala
@@ -386,13 +386,10 @@ object QueryServiceTest extends DefaultRunnableSpec {
     testChemicalToGeneOrGeneProduct,
     testChemicalSubstanceKCNMA1,
     testDILIGeneList,
-    // The following tests currently fail. These failures are documented in the respective issues:
-    // - https://github.com/ExposuresProvider/cam-kp-api/issues/517
-    testSimpleQuery @@ TestAspect.failing,
-    testSimpleQueryRaw @@ TestAspect.failing,
-    testSimpleQueryRawWithSinglePredicate @@ TestAspect.failing,
-    // - https://github.com/ExposuresProvider/cam-kp-api/issues/518
-    testRelatedToQuery @@ TestAspect.failing,
+    testSimpleQuery,
+    testSimpleQueryRaw,
+    testSimpleQueryRawWithSinglePredicate,
+    testRelatedToQuery,
   ).provideLayerShared(testLayer) @@ TestAspect.sequential
 
 }

--- a/src/it/scala/org/renci/cam/it/QueryServiceTest.scala
+++ b/src/it/scala/org/renci/cam/it/QueryServiceTest.scala
@@ -381,15 +381,18 @@ object QueryServiceTest extends DefaultRunnableSpec {
     testAcrocyanosis,
     testPathway,
     testERAD,
-    testRelatedToQuery,
     testWIKIQueryExample,
-    testSimpleQueryRawWithSinglePredicate,
-    testSimpleQueryRaw,
     testKCNMA1DiseasePhenotypicFeat,
     testChemicalToGeneOrGeneProduct,
     testChemicalSubstanceKCNMA1,
     testDILIGeneList,
-    testSimpleQuery
+    // The following tests currently fail. These failures are documented in the respective issues:
+    // - https://github.com/ExposuresProvider/cam-kp-api/issues/517
+    testSimpleQuery @@ TestAspect.failing,
+    testSimpleQueryRaw @@ TestAspect.failing,
+    testSimpleQueryRawWithSinglePredicate @@ TestAspect.failing,
+    // - https://github.com/ExposuresProvider/cam-kp-api/issues/518
+    testRelatedToQuery @@ TestAspect.failing,
   ).provideLayerShared(testLayer) @@ TestAspect.sequential
 
 }

--- a/src/main/scala/org/renci/cam/QueryService.scala
+++ b/src/main/scala/org/renci/cam/QueryService.scala
@@ -259,7 +259,7 @@ object QueryService extends LazyLogging {
       allPredicatesInQuery = queryGraph.edges.values.flatMap(_.predicates.getOrElse(Nil)).to(Set)
       predicatesToRelations <- mapQueryBiolinkPredicatesToRelations(allPredicatesInQuery)
       allRelationsInQuery = predicatesToRelations.values.flatten.to(Set)
-      relationsToLabelAndBiolinkPredicate: Map[IRI, (Option[String], IRI)] <- mapRelationsToLabelAndBiolink(allRelationsInQuery)
+      relationsToLabelAndBiolinkPredicate <- mapRelationsToLabelAndBiolink(allRelationsInQuery)
 
       // Generate query solutions.
       _ = logger.debug(s"findInitialQuerySolutions(${queryGraph}, ${predicatesToRelations}, ${limit})")

--- a/src/main/scala/org/renci/cam/QueryService.scala
+++ b/src/main/scala/org/renci/cam/QueryService.scala
@@ -156,6 +156,9 @@ object QueryService extends LazyLogging {
       sparql""" VALUES ${edgeVar}_class { ${idsList.asValues} }
                       $edgeVar $RDFType ${edgeVar}_class .
                       """
+    case (None, Some(List(BiolinkNamedThing))) =>
+      // Since everything is a Biolink Named Thing, we don't actually need to filter to it.
+      sparql""
     case (None, Some(biolinkTypes)) =>
       val irisList = biolinkTypes.map(_.iri)
       sparql""" VALUES ${edgeVar}_class { ${irisList.asValues} }

--- a/src/main/scala/org/renci/cam/QueryService.scala
+++ b/src/main/scala/org/renci/cam/QueryService.scala
@@ -597,7 +597,7 @@ object QueryService extends LazyLogging {
   def getTRAPIEdgeBindingsMany(queryGraph: TRAPIQueryGraph,
                                querySolutions: List[QuerySolution],
                                relationsMap: Map[IRI, (Option[String], IRI)])
-    : ZIO[Has[BiolinkData], Throwable, Map[QuerySolution, Map[String, List[TRAPIEdgeBinding]]]] =
+    : RIO[Has[BiolinkData], Map[QuerySolution, Map[String, List[TRAPIEdgeBinding]]]] =
     for {
       biolinkData <- biolinkData
       querySolutionsToEdgeBindings <- ZIO.foreach(querySolutions) { querySolution =>

--- a/src/main/scala/org/renci/cam/QueryService.scala
+++ b/src/main/scala/org/renci/cam/QueryService.scala
@@ -566,6 +566,8 @@ object QueryService extends LazyLogging {
     nodeMap
   }
 
+  // TODO:
+  // - Change this to cached queries (see mapQueryBiolinkPredicatesToRelations for example)
   def mapRelationsToLabelAndBiolink(relations: Set[IRI]): RIO[ZConfig[AppConfig] with HttpClient, Map[IRI, (Option[String], IRI)]] = {
     final case class RelationInfo(relation: IRI, biolinkSlot: IRI, label: Option[String])
     val queryText = sparql"""

--- a/src/main/scala/org/renci/cam/QueryService.scala
+++ b/src/main/scala/org/renci/cam/QueryService.scala
@@ -559,6 +559,7 @@ object QueryService extends LazyLogging {
     for {
       queryText <- Task.effect(getTRAPINodeDetailsQueryText(nodeIdList))
       termsAndBiolinkTypes <- SPARQLQueryExecutor.runSelectQueryAs[TermWithLabelAndBiolinkType](queryText.toQuery)
+      _ = logger.debug(s"getTRAPINodeDetails(${nodeIdList}) = ${termsAndBiolinkTypes}")
     } yield termsAndBiolinkTypes
 
   def getTRAPINodeBindings(queryGraph: TRAPIQueryGraph,

--- a/src/main/scala/org/renci/cam/QueryService.scala
+++ b/src/main/scala/org/renci/cam/QueryService.scala
@@ -17,8 +17,6 @@ import zio.{Has, RIO, Task, UIO, ZIO, config => _}
 import java.math.BigInteger
 import java.nio.charset.StandardCharsets
 import java.security.MessageDigest
-import java.util.UUID
-import scala.collection.{immutable, mutable}
 import scala.jdk.CollectionConverters._
 
 object QueryService extends LazyLogging {
@@ -248,6 +246,11 @@ object QueryService extends LazyLogging {
       // Get the Biolink data.
       biolinkData <- biolinkData
       _ = logger.debug("limit: {}, includeExtraEdges: {}", limit, includeExtraEdges)
+
+      // We don't actually support `includeExtraEdges`, so if this is set, we should throw an unimplemented exception.
+      includeExtraEdgesFlag <- if (includeExtraEdges)
+        ZIO.fail(new NotImplementedError("includeExtraEdges not yet supported in QueryService.run()"))
+      else ZIO.succeed(false)
 
       // Prepare the query graph for processing.
       queryGraph = enforceQueryEdgeTypes(submittedQueryGraph, biolinkData.predicates)

--- a/src/main/scala/org/renci/cam/QueryService.scala
+++ b/src/main/scala/org/renci/cam/QueryService.scala
@@ -364,29 +364,29 @@ object QueryService extends LazyLogging {
               }
             """
     }
-    val node_projections = getProjections(queryGraph)
-    val type_projections = getProjections(queryGraph, true)
+    val nodeProjections = getProjections(queryGraph)
+    val typeProjections = getProjections(queryGraph, true)
     val nodesToDirectTypes = getNodesToDirectTypes(queryGraph.nodes.keySet)
     val edgePatterns = queryEdgeSparql.fold(sparql"")(_ + _)
     val limitSparql = if (limit > 0) sparql" LIMIT $limit" else sparql""
     val queryString =
       sparql"""PREFIX hint: <http://www.bigdata.com/queryHints#>
 
-          SELECT DISTINCT $type_projections
+          SELECT DISTINCT $typeProjections
                (GROUP_CONCAT(DISTINCT ?g; SEPARATOR='|') AS ?graphs)
                (GROUP_CONCAT(DISTINCT ?d; SEPARATOR='|') AS ?derivedFrom)
           WHERE {
             $nodesToDirectTypes
             OPTIONAL { ?g $ProvWasDerivedFrom ?d }
             {
-              SELECT $node_projections ?g
+              SELECT $nodeProjections ?g
               WHERE {
                 $edgePatterns
               }
             }
             hint:Prior hint:runFirst true .
           }
-          GROUP BY $type_projections
+          GROUP BY $typeProjections
           $limitSparql
           """
     logger.debug(s"Executing query: ${queryString}")

--- a/src/main/scala/org/renci/cam/QueryService.scala
+++ b/src/main/scala/org/renci/cam/QueryService.scala
@@ -145,11 +145,11 @@ object QueryService extends LazyLogging {
       sparql"""PREFIX hint: <http://www.bigdata.com/queryHints#>
 
           SELECT DISTINCT $type_projections
-               (GROUP_CONCAT(DISTINCT ?g; SEPARATOR='|') AS ?groups)
-               (GROUP_CONCAT(DISTINCT ?other; SEPARATOR='|') AS ?others)
+               (GROUP_CONCAT(DISTINCT ?g; SEPARATOR='|') AS ?graphs)
+               (GROUP_CONCAT(DISTINCT ?d; SEPARATOR='|') AS ?derivedFrom)
           WHERE {
             $nodesToDirectTypes
-            OPTIONAL { ?g $ProvWasDerivedFrom ?other }
+            OPTIONAL { ?g $ProvWasDerivedFrom ?d }
             {
               SELECT $node_projections ?g
               WHERE {

--- a/src/main/scala/org/renci/cam/domain/package.scala
+++ b/src/main/scala/org/renci/cam/domain/package.scala
@@ -34,6 +34,12 @@ package object domain {
 
     }
 
+    /**
+     * An implicit method for converting an IRI into an RDFNode.
+     *
+     * @param iri The IRI to convert to an RDFNode.
+     * @return The RDFNode representing the provided IRI.
+     */
     implicit def toRDFNode(iri: IRI): RDFNode = new ResourceImpl(iri.value)
 
     implicit val schema: Schema[IRI] = Schema.string

--- a/src/main/scala/org/renci/cam/domain/package.scala
+++ b/src/main/scala/org/renci/cam/domain/package.scala
@@ -4,6 +4,8 @@ import com.google.common.base.CaseFormat
 import contextual.Case
 import org.apache.commons.lang3.StringUtils
 import org.apache.jena.query.{ParameterizedSparqlString, QuerySolution}
+import org.apache.jena.rdf.model.RDFNode
+import org.apache.jena.rdf.model.impl.ResourceImpl
 import org.apache.jena.sparql.core.{Var => JenaVar}
 import org.phenoscape.sparql.FromQuerySolution
 import org.phenoscape.sparql.SPARQLInterpolation.SPARQLInterpolator
@@ -31,6 +33,8 @@ package object domain {
         getResource(qs, variablePath).map(r => IRI(r.getURI))
 
     }
+
+    implicit def toRDFNode(iri: IRI): RDFNode = new ResourceImpl(iri.value)
 
     implicit val schema: Schema[IRI] = Schema.string
 

--- a/src/main/scala/org/renci/cam/domain/package.scala
+++ b/src/main/scala/org/renci/cam/domain/package.scala
@@ -3,9 +3,9 @@ package org.renci.cam
 import com.google.common.base.CaseFormat
 import contextual.Case
 import org.apache.commons.lang3.StringUtils
+import org.apache.jena.iri.IRIFactory
 import org.apache.jena.query.{ParameterizedSparqlString, QuerySolution}
-import org.apache.jena.rdf.model.RDFNode
-import org.apache.jena.rdf.model.impl.ResourceImpl
+import org.apache.jena.rdf.model.{RDFNode, ResourceFactory}
 import org.apache.jena.sparql.core.{Var => JenaVar}
 import org.phenoscape.sparql.FromQuerySolution
 import org.phenoscape.sparql.SPARQLInterpolation.SPARQLInterpolator
@@ -37,10 +37,15 @@ package object domain {
     /**
      * An implicit method for converting an IRI into an RDFNode.
      *
+     * It's probably good enough to treat iri.value as a URI, but _just in case_
+     * we use Jena's IRIFactory to convert it into an URI first.
+     *
      * @param iri The IRI to convert to an RDFNode.
      * @return The RDFNode representing the provided IRI.
      */
-    implicit def toRDFNode(iri: IRI): RDFNode = new ResourceImpl(iri.value)
+    implicit def toNode(iri: IRI): RDFNode = ResourceFactory.createResource(
+      IRIFactory.iriImplementation().construct(iri.value).toURI.toString
+    )
 
     implicit val schema: Schema[IRI] = Schema.string
 

--- a/src/test/scala/org/renci/cam/test/LimitTest.scala
+++ b/src/test/scala/org/renci/cam/test/LimitTest.scala
@@ -40,9 +40,9 @@ object LimitTest extends DefaultRunnableSpec with LazyLogging {
     def generateTestForLimit(limit: Int) =
       testM(f"Test query with ${queryGraphExpectedResults} results, limit ${limit}") {
         for {
-          exec <- QueryService.run(limit, false, testQueryGraph)
-          _ = println(f"Obtained ${exec.results.get.size} results when limited to ${limit}")
-          results = exec.results.get
+          message <- QueryService.run(limit, false, testQueryGraph)
+          _ = println(f"Retrieved ${message.results.get.size} results when limit=${limit}")
+          results = message.results.get
         } yield {
           assert(results.size)(Assertion.isGreaterThan(0)) &&
             assert(results.size)(Assertion.equalTo(Math.min(queryGraphExpectedResults, limit)))
@@ -60,7 +60,13 @@ object LimitTest extends DefaultRunnableSpec with LazyLogging {
       generateTestForLimit(10),
       generateTestForLimit(20),
       generateTestForLimit(30),
-      generateTestForLimit(40)
+      generateTestForLimit(40),
+      generateTestForLimit(50),
+      generateTestForLimit(60),
+      generateTestForLimit(70),
+      generateTestForLimit(80),
+      generateTestForLimit(90),
+      generateTestForLimit(100)
     )
   }
 

--- a/src/test/scala/org/renci/cam/test/LimitTest.scala
+++ b/src/test/scala/org/renci/cam/test/LimitTest.scala
@@ -26,7 +26,7 @@ import zio.test.environment.testEnvironment
 object LimitTest extends DefaultRunnableSpec with LazyLogging {
 
   val testQueryWithExpectedResults = {
-    val queryGraphExpectedResults = 14 // expected results as of 2022-mar-23
+    val queryGraphExpectedResults = 25 // expected results as of 2022-mar-23
     val testQueryGraph = TRAPIQueryGraph(
       Map(
         "n0" -> TRAPIQueryNode(Some(List(IRI("http://purl.obolibrary.org/obo/CHEBI_15361"))), None, None),

--- a/src/test/scala/org/renci/cam/test/LimitTest.scala
+++ b/src/test/scala/org/renci/cam/test/LimitTest.scala
@@ -53,11 +53,9 @@ object LimitTest extends DefaultRunnableSpec with LazyLogging {
   }
 
   val configLayer: Layer[Throwable, ZConfig[AppConfig]] = TypesafeConfig.fromDefaultLoader(AppConfig.config)
-  val sparqlCacheLayer = SPARQLQueryExecutor.makeCache.toLayer
-  val camkpapiLayer = Blocking.live >>> HttpClient.makeHttpClientLayer >+> Biolink.makeUtilitiesLayer
-  val testLayer = (configLayer ++ camkpapiLayer).mapError(TestFailure.die)
+  val testLayer = HttpClient.makeHttpClientLayer >+> Biolink.makeUtilitiesLayer ++ configLayer >+> SPARQLQueryExecutor.makeCache.toLayer
 
   def spec = suite("Limit tests")(
     testVariousLimits
-  ).provideLayerShared(testLayer)
+  ).provideCustomLayer(testLayer.mapError(TestFailure.die))
 }

--- a/src/test/scala/org/renci/cam/test/LimitTest.scala
+++ b/src/test/scala/org/renci/cam/test/LimitTest.scala
@@ -46,6 +46,16 @@ object LimitTest extends DefaultRunnableSpec with LazyLogging {
             _ = println(s"Retrieved ${message.results.get.size} results when limit=${limit}")
             results = message.results.get
           } yield {
+            logger.info(s"Knowledge graph:")
+            logger.info(s" - Nodes:")
+            message.knowledge_graph.foreach(_.nodes.foreach(node =>
+              logger.info(s"   - ${node._1}: ${node._2}")
+            ))
+            logger.info(s" - Edges:")
+            message.knowledge_graph.foreach(_.edges.foreach(edge =>
+              logger.info(s"   - ${edge._1}: ${edge._2}")
+            ))
+
             logger.info(s"Results:")
             for ((r, index) <- results.zipWithIndex) {
               logger.info(s" - [${index + 1}] ${r}")

--- a/src/test/scala/org/renci/cam/test/LimitTest.scala
+++ b/src/test/scala/org/renci/cam/test/LimitTest.scala
@@ -1,24 +1,13 @@
 package org.renci.cam.test
 
 import com.typesafe.scalalogging.LazyLogging
-import io.circe.syntax._
-import io.circe.{Encoder, Json}
-import org.apache.jena.query.{Query, QuerySolution}
-import org.renci.cam.HttpClient.HttpClient
-import org.renci.cam.SPARQLQueryExecutor.SPARQLCache
-import org.renci.cam.{AppConfig, Biolink, HttpClient, QueryService, SPARQLQueryExecutor}
 import org.renci.cam.domain._
-import zio.ExecutionStrategy.Sequential
-import zio.blocking.Blocking
-import zio.cache.Cache
-import zio.config.{ConfigModule, ZConfig}
-import zio.{Layer, RIO, Runtime, ZIO, ZLayer}
+import org.renci.cam._
+import zio.Layer
+import zio.config.ZConfig
 import zio.config.typesafe.TypesafeConfig
 import zio.stream.ZStream
-import zio.test.Assertion._
-import zio.test.TestAspect.{debug, ignore}
 import zio.test._
-import zio.test.environment.testEnvironment
 
 /**
  * Tests whether queries work as expected with limits, i.e. given a query, can we increase limits arbitrarily
@@ -26,8 +15,16 @@ import zio.test.environment.testEnvironment
  */
 object LimitTest extends DefaultRunnableSpec with LazyLogging {
 
+  /**
+   * For a query with a certain number of expected results, this code block creates a number of tests that test
+   * whether setting `limit` from 1..50 return the correct number of expected results.
+   */
   val testQueryWithExpectedResults = {
-    val queryGraphExpectedResults = 30 // expected results as of 2022-may-18
+    // Expected results as of 2022-may-18 for the test query
+    val queryGraphExpectedResults = 30
+    // The limits to test -- this should be set up to go neatly within
+    val limitsToTest = Seq(1, 2, 3, 4, 5, 10, 20, 30, 40, 50)
+    // The test query: pyruvate related_to $[NamedThing]
     val testQueryGraph = TRAPIQueryGraph(
       Map(
         "n0" -> TRAPIQueryNode(Some(List(IRI("http://purl.obolibrary.org/obo/CHEBI_15361"))), None, None),
@@ -38,31 +35,28 @@ object LimitTest extends DefaultRunnableSpec with LazyLogging {
       )
     )
 
-    val limitsToTest = Seq(1, 2, 3, 4, 5, 10, 20, 30, 40, 50)
     suiteM("testQueryWithExpectedResults") {
       ZStream.fromIterable(limitsToTest)
         .map(limit => testM(s"Test query with limit of ${limit} expecting ${queryGraphExpectedResults} results") {
           for {
             message <- QueryService.run(limit, false, testQueryGraph)
-            _ = println(s"Retrieved ${message.results.get.size} results when limit=${limit}")
+            _ = logger.info(s"Retrieved ${message.results.get.size} results when limit=${limit}")
             results = message.results.get
           } yield {
-            /*
-            logger.info(s"Knowledge graph:")
-            logger.info(s" - Nodes:")
+            logger.debug(s"Knowledge graph:")
+            logger.debug(s" - Nodes:")
             message.knowledge_graph.foreach(_.nodes.foreach(node =>
-              logger.info(s"   - ${node._1}: ${node._2}")
+              logger.debug(s"   - ${node._1}: ${node._2}")
             ))
-            logger.info(s" - Edges:")
+            logger.debug(s" - Edges:")
             message.knowledge_graph.foreach(_.edges.foreach(edge =>
-              logger.info(s"   - ${edge._1}: ${edge._2}")
+              logger.debug(s"   - ${edge._1}: ${edge._2}")
             ))
-
-            logger.info(s"Results:")
+            logger.debug(s"Results:")
             for ((r, index) <- results.zipWithIndex) {
-              logger.info(s" - [${index + 1}] ${r}")
+              logger.debug(s" - [${index + 1}] ${r}")
             }
-             */
+
             assert(results.size)(Assertion.isGreaterThan(0)) &&
               assert(results.size)(Assertion.equalTo(Math.min(queryGraphExpectedResults, limit)))
           }
@@ -73,7 +67,7 @@ object LimitTest extends DefaultRunnableSpec with LazyLogging {
   val configLayer: Layer[Throwable, ZConfig[AppConfig]] = TypesafeConfig.fromDefaultLoader(AppConfig.config)
   val testLayer = HttpClient.makeHttpClientLayer ++ Biolink.makeUtilitiesLayer ++ configLayer >+> SPARQLQueryExecutor.makeCache.toLayer
 
-  def spec = suite("Limit tests")(
+  def spec: Spec[environment.TestEnvironment, TestFailure[Throwable], TestSuccess] = suite("Limit tests")(
     testQueryWithExpectedResults
   ).provideCustomLayer(testLayer.mapError(TestFailure.die))
 }

--- a/src/test/scala/org/renci/cam/test/LimitTest.scala
+++ b/src/test/scala/org/renci/cam/test/LimitTest.scala
@@ -1,0 +1,63 @@
+package org.renci.cam.test
+
+import com.typesafe.scalalogging.LazyLogging
+import io.circe.syntax._
+import io.circe.{Encoder, Json}
+import org.apache.jena.query.{Query, QuerySolution}
+import org.renci.cam.HttpClient.HttpClient
+import org.renci.cam.SPARQLQueryExecutor.SPARQLCache
+import org.renci.cam.{AppConfig, Biolink, HttpClient, QueryService, SPARQLQueryExecutor}
+import org.renci.cam.domain._
+import zio.ExecutionStrategy.Sequential
+import zio.blocking.Blocking
+import zio.cache.Cache
+import zio.config.{ConfigModule, ZConfig}
+import zio.{Layer, ZIO, ZLayer}
+import zio.config.typesafe.TypesafeConfig
+import zio.test.Assertion._
+import zio.test.TestAspect.{debug, ignore}
+import zio.test._
+import zio.test.environment.testEnvironment
+
+/**
+ * Tests whether queries work as expected with limits, i.e. given a query, can we increase limits arbitrarily
+ * and see consistently increasing numbers of results?
+ */
+object LimitTest extends DefaultRunnableSpec with LazyLogging {
+
+  val testVariousLimits = {
+    val limitsToTest = List(10, 20, 30, 40)
+    val testQueryGraph = TRAPIQueryGraph(
+      Map(
+        "n0" -> TRAPIQueryNode(Some(List(IRI("http://purl.obolibrary.org/obo/CHEBI_15361"))), None, None),
+        "n1" -> TRAPIQueryNode(None, Some(List(BiolinkClass("NamedThing"))), None)
+      ),
+      Map(
+        "e0" -> TRAPIQueryEdge(Some(List(BiolinkPredicate("related_to"))), "n0", "n1", None)
+      )
+    )
+
+    suite("testVariousLimits")(
+      testM("Test a limit of 10") {
+        val limit = 10
+        for {
+          exec <- QueryService.run(limit, false, testQueryGraph)
+          _ = logger.debug(f"Obtained ${exec.results.get.size} results when querying for ${limit}")
+          results = exec.results.get
+        } yield {
+          assert(results.size)(Assertion.isGreaterThan(0)) &&
+            assert(results.size)(Assertion.isLessThanEqualTo(limit))
+        }
+      }
+    )
+  }
+
+  val configLayer: Layer[Throwable, ZConfig[AppConfig]] = TypesafeConfig.fromDefaultLoader(AppConfig.config)
+  val sparqlCacheLayer = SPARQLQueryExecutor.makeCache.toLayer
+  val camkpapiLayer = Blocking.live >>> HttpClient.makeHttpClientLayer >+> Biolink.makeUtilitiesLayer
+  val testLayer = (configLayer ++ camkpapiLayer).mapError(TestFailure.die)
+
+  def spec = suite("Limit tests")(
+    testVariousLimits
+  ).provideLayerShared(testLayer)
+}

--- a/src/test/scala/org/renci/cam/test/LimitTest.scala
+++ b/src/test/scala/org/renci/cam/test/LimitTest.scala
@@ -35,6 +35,11 @@ object LimitTest extends DefaultRunnableSpec with LazyLogging {
       )
     )
 
+    /*
+     * Try querying the test query, and check to see if (1) we get back the expected number of results
+     * (this will change as the backend changes) and (2) make sure that we get back the correct number
+     * of limited results as we adjust the limit as per `limitsToTest`.
+     */
     suiteM("testQueryWithExpectedResults") {
       ZStream.fromIterable(limitsToTest)
         .map(limit => testM(s"Test query with limit of ${limit} expecting ${queryGraphExpectedResults} results") {

--- a/src/test/scala/org/renci/cam/test/LimitTest.scala
+++ b/src/test/scala/org/renci/cam/test/LimitTest.scala
@@ -46,6 +46,10 @@ object LimitTest extends DefaultRunnableSpec with LazyLogging {
             _ = println(s"Retrieved ${message.results.get.size} results when limit=${limit}")
             results = message.results.get
           } yield {
+            logger.info(s"Results:")
+            for ((r, index) <- results.zipWithIndex) {
+              logger.info(s" - [${index + 1}] ${r}")
+            }
             assert(results.size)(Assertion.isGreaterThan(0)) &&
               assert(results.size)(Assertion.equalTo(Math.min(queryGraphExpectedResults, limit)))
           }

--- a/src/test/scala/org/renci/cam/test/LimitTest.scala
+++ b/src/test/scala/org/renci/cam/test/LimitTest.scala
@@ -26,7 +26,7 @@ import zio.test.environment.testEnvironment
 object LimitTest extends DefaultRunnableSpec with LazyLogging {
 
   val testQueryWithExpectedResults = {
-    val queryGraphExpectedResults = 25 // expected results as of 2022-mar-23
+    val queryGraphExpectedResults = 30 // expected results as of 2022-may-18
     val testQueryGraph = TRAPIQueryGraph(
       Map(
         "n0" -> TRAPIQueryNode(Some(List(IRI("http://purl.obolibrary.org/obo/CHEBI_15361"))), None, None),

--- a/src/test/scala/org/renci/cam/test/QueryServiceTest.scala
+++ b/src/test/scala/org/renci/cam/test/QueryServiceTest.scala
@@ -356,16 +356,7 @@ object QueryServiceTest extends DefaultRunnableSpec with LazyLogging {
 
       },*/
       zio.test.testM("Test getTRAPINodeBindings()") {
-        // getTRAPIEdgeBindingsMany(
-        //  TRAPIQueryGraph(
-        //    Map(
-        //      n0 -> TRAPIQueryNode(Some(List(IRI(http://purl.obolibrary.org/obo/CHEBI_15361))),Some(List(BiolinkClass(NamedThing,IRI(https://w3id.org/biolink/vocab/NamedThing)))),None),
-        //      n1 -> TRAPIQueryNode(None,Some(List(BiolinkClass(NamedThing,IRI(https://w3id.org/biolink/vocab/NamedThing)))),None)),
-        //      Map(e0 -> TRAPIQueryEdge(Some(List(BiolinkPredicate(related_to,IRI(https://w3id.org/biolink/vocab/related_to)))),n0,n1,None))),
-        //      List(
-        //        ( ?n1_type = <http://purl.obolibrary.org/obo/GO_0006094> ) ( ?e0 = <http://purl.obolibrary.org/obo/RO_0000056> ) ( ?n1 = <http://model.geneontology.org/R-HSA-70263/R-HSA-70263> ) ( ?n0_type = <http://purl.obolibrary.org/obo/CHEBI_15361> ) ( ?n0 = <http://model.geneontology.org/R-ALL-113557_R-HSA-70501> ), ( ?n1_type = <http://purl.obolibrary.org/obo/GO_0046034> ) ( ?e0 = <http://purl.obolibrary.org/obo/RO_0000056> ) ( ?n1 = <http://model.geneontology.org/R-HSA-70263/R-HSA-70263> ) ( ?n0_type = <http://purl.obolibrary.org/obo/CHEBI_15361> ) ( ?n0 = <http://model.geneontology.org/R-ALL-113557_R-HSA-70501> ), ( ?n1_type = <http://purl.obolibrary.org/obo/GO_0046034> ) ( ?e0 = <http://purl.obolibrary.org/obo/RO_0000056> ) ( ?n1 = <http://model.geneontology.org/R-HSA-73621/R-HSA-73621> ) ( ?n0_type = <http://purl.obolibrary.org/obo/CHEBI_15361> ) ( ?n0 = <http://model.geneontology.org/R-ALL-113557_R-HSA-909776> )),
-        //        HashMap()
-
+        // List((Map(n0 -> List(TRAPINodeBinding(IRI(http://purl.obolibrary.org/obo/CHEBI_15361))), n1 -> List(TRAPINodeBinding(IRI(http://purl.obolibrary.org/obo/GO_0006094)))),Map(e0 -> List(TRAPIEdgeBinding(309229ebbc25b5b04fe79bf560d9ea20c1831703fa98605b4e97f78d73b47c56)))), (Map(n0 -> List(TRAPINodeBinding(IRI(http://purl.obolibrary.org/obo/CHEBI_15361))), n1 -> List(TRAPINodeBinding(IRI(http://purl.obolibrary.org/obo/GO_0046034)))),Map(e0 -> List(TRAPIEdgeBinding(3e27e38fc631bbfaac62c84dbe8e475895797f6fe663a852d916df24a0522339)))), (Map(n0 -> List(TRAPINodeBinding(IRI(http://purl.obolibrary.org/obo/CHEBI_15361))), n1 -> List(TRAPINodeBinding(IRI(http://purl.obolibrary.org/obo/GO_0046034>)))),Map(e0 -> List(TRAPIEdgeBinding(86cf45a0368b1fbf6dd93a9e6bdd1b6fcc030d53389d4e8b3e4d81e850ba0420)))))
         for {
           querySolutionsToEdgeBindings <- QueryService.getTRAPIEdgeBindingsMany(queryGraph, initialQuerySolutions, relationsToLabelAndBiolinkPredicate)
           trapiBindings <- ZIO.foreach(initialQuerySolutions) { querySolution =>
@@ -373,7 +364,11 @@ object QueryServiceTest extends DefaultRunnableSpec with LazyLogging {
               Task.effect(querySolutionsToEdgeBindings(querySolution))
           }
         } yield {
-          assert(trapiBindings)(Assertion.equalTo(List()))
+          // We should have three results
+          assert(trapiBindings.length)(Assertion.equalTo(3)) &&
+          // Each result should have two nodes and one edge
+            assert(trapiBindings.flatMap(_._1.keys).distinct.toSet)(Assertion.equalTo(Set("n0", "n1"))) &&
+            assert(trapiBindings.flatMap(_._2.keys).distinct.toSet)(Assertion.equalTo(Set("e0")))
         }
       }
     )

--- a/src/test/scala/org/renci/cam/test/QueryServiceTest.scala
+++ b/src/test/scala/org/renci/cam/test/QueryServiceTest.scala
@@ -173,7 +173,7 @@ object QueryServiceTest extends DefaultRunnableSpec with LazyLogging {
   val testGetNodesToDirectTypes = suite("testGetNodesToDirectTypes")(
     zio.test.test("test QueryService.getNodesToDirectTypes") {
       val (queryGraph, _) = getSimpleData
-      val queryText = QueryService.getNodesToDirectTypes(queryGraph.nodes.keySet)
+      val queryText = QueryService.getNodesToDirectTypes(queryGraph.nodes)
       assert(queryText.text.trim)(
         containsString("?n0 <http://www.openrdf.org/schema/sesame#directType> ?n0_type .") && containsString(
           "?n1 <http://www.openrdf.org/schema/sesame#directType> ?n1_type .")

--- a/src/test/scala/org/renci/cam/test/QueryServiceTest.scala
+++ b/src/test/scala/org/renci/cam/test/QueryServiceTest.scala
@@ -69,8 +69,9 @@ object QueryServiceTest extends DefaultRunnableSpec with LazyLogging {
     testM("test QueryService.enforceQueryEdgeTypes") {
       for {
         nodeTypes <- ZIO.effect(QueryService.enforceQueryEdgeTypes(queryGraph, List(BiolinkPredicate("related_to"))))
-      } yield assert(nodeTypes.edges)(hasKey("e0")) && assert(nodeTypes.edges("e0").predicates.get)(
-        equalTo(List(BiolinkPredicate("related_to"))))
+      } yield {
+        assert(nodeTypes.edges)(hasKey("e0")) && assertTrue(nodeTypes.edges("e0").predicates.get == List(BiolinkPredicate("related_to")))
+      }
     }
   )
 
@@ -81,8 +82,7 @@ object QueryServiceTest extends DefaultRunnableSpec with LazyLogging {
         nodeBindings <- QueryService.getTRAPINodeBindings(queryGraph, resultSet.next())
       } yield assert(nodeBindings.keys)(
         contains("n0") && contains("n1")
-      ) && assert(nodeBindings.get("n0").get.map(a => a.id))(
-        contains(IRI("http://purl.obolibrary.org/obo/go/extensions/reacto.owl#REACTO_R-HSA-166103")))
+      ) && assertTrue(nodeBindings.get("n0").get.map(a => a.id).contains(IRI("http://purl.obolibrary.org/obo/go/extensions/reacto.owl#REACTO_R-HSA-166103")))
     }
   )
 
@@ -135,8 +135,7 @@ object QueryServiceTest extends DefaultRunnableSpec with LazyLogging {
       )
       for {
         queryText <- Task.effect(QueryService.getTRAPINodeDetailsQueryText(nodeIdList))
-      } yield assert(queryText.text)(
-        containsString("VALUES ?term {  <http://purl.obolibrary.org/obo/GO_0047196>  <http://purl.obolibrary.org/obo/GO_0017064>  }"))
+      } yield assertTrue(queryText.text.contains("VALUES ?term {  <http://purl.obolibrary.org/obo/GO_0047196>  <http://purl.obolibrary.org/obo/GO_0017064>  }"))
     },
     testM("test QueryService.getProvenanceQueryText") {
       for {
@@ -167,7 +166,7 @@ object QueryServiceTest extends DefaultRunnableSpec with LazyLogging {
     testM("test QueryService.getCAMStuffQueryText") {
       for {
         queryText <- Task.effect(QueryService.getCAMStuffQueryText(IRI("http://model.geneontology.org/R-HSA-2142753")))
-      } yield assert(queryText.text)(containsString("{ GRAPH <http://model.geneontology.org/R-HSA-2142753>"))
+      } yield assertTrue(queryText.text.contains("{ GRAPH <http://model.geneontology.org/R-HSA-2142753>"))
     }
   )
 
@@ -401,8 +400,7 @@ object QueryServiceTest extends DefaultRunnableSpec with LazyLogging {
 
   val configLayer: Layer[Throwable, ZConfig[AppConfig]] = TypesafeConfig.fromDefaultLoader(AppConfig.config)
   val testLayer = HttpClient.makeHttpClientLayer ++ Biolink.makeUtilitiesLayer ++ configLayer >+> SPARQLQueryExecutor.makeCache.toLayer
-
-
+  
   def spec = suite("QueryService tests")(
     testIncludeExtraEdges,
 //    testGetNodeTypes,

--- a/src/test/scala/org/renci/cam/test/QueryServiceTest.scala
+++ b/src/test/scala/org/renci/cam/test/QueryServiceTest.scala
@@ -359,7 +359,7 @@ object QueryServiceTest extends DefaultRunnableSpec with LazyLogging {
         // List((Map(n0 -> List(TRAPINodeBinding(IRI(http://purl.obolibrary.org/obo/CHEBI_15361))), n1 -> List(TRAPINodeBinding(IRI(http://purl.obolibrary.org/obo/GO_0006094)))),Map(e0 -> List(TRAPIEdgeBinding(309229ebbc25b5b04fe79bf560d9ea20c1831703fa98605b4e97f78d73b47c56)))), (Map(n0 -> List(TRAPINodeBinding(IRI(http://purl.obolibrary.org/obo/CHEBI_15361))), n1 -> List(TRAPINodeBinding(IRI(http://purl.obolibrary.org/obo/GO_0046034)))),Map(e0 -> List(TRAPIEdgeBinding(3e27e38fc631bbfaac62c84dbe8e475895797f6fe663a852d916df24a0522339)))), (Map(n0 -> List(TRAPINodeBinding(IRI(http://purl.obolibrary.org/obo/CHEBI_15361))), n1 -> List(TRAPINodeBinding(IRI(http://purl.obolibrary.org/obo/GO_0046034>)))),Map(e0 -> List(TRAPIEdgeBinding(86cf45a0368b1fbf6dd93a9e6bdd1b6fcc030d53389d4e8b3e4d81e850ba0420)))))
         for {
           querySolutionsToEdgeBindings <- QueryService.getTRAPIEdgeBindingsMany(queryGraph, initialQuerySolutions, relationsToLabelAndBiolinkPredicate)
-          _ = println(s"querySolutionsToEdgeBindings: ${querySolutionsToEdgeBindings} (length: ${querySolutionsToEdgeBindings.size})")
+          _ = logger.debug(s"querySolutionsToEdgeBindings: ${querySolutionsToEdgeBindings} (length: ${querySolutionsToEdgeBindings.size})")
           trapiBindings <- ZIO.foreach(initialQuerySolutions) { querySolution =>
             QueryService.getTRAPINodeBindings(queryGraph, querySolution) zip
               Task.effect(querySolutionsToEdgeBindings(querySolution))


### PR DESCRIPTION
I noticed some odd behavior with the way in which the `limit` parameter works, which can be best summarized by listing the results of running the same query against the SPARQL endpoint using the new test I've written in this PR.

```
Retrieved 14 results when limit=0
Retrieved 1 results when limit=1
Retrieved 2 results when limit=2
Retrieved 2 results when limit=3
Retrieved 2 results when limit=4
Retrieved 3 results when limit=5
Retrieved 6 results when limit=10
Retrieved 13 results when limit=20
Retrieved 14 results when limit=30
Retrieved 14 results when limit=40
Retrieved 14 results when limit=50
Retrieved 14 results when limit=60
Retrieved 14 results when limit=70
Retrieved 14 results when limit=80
Retrieved 14 results when limit=90
Retrieved 14 results when limit=100
```

This PR updates the SPARQL query generation code (in consultation with Jim) to correct this bug so we return the correct number of results. It retains the previously used code since there is functionality in there that we would probably like reuse in the future.

This PR previously introduced two new bugs (#517, #518) but then closes them in d4ccd3a9eb45f.