### PR TITLE
Replace OpenAPI example

### DIFF
--- a/src/main/scala/org/renci/cam/Server.scala
+++ b/src/main/scala/org/renci/cam/Server.scala
@@ -100,9 +100,11 @@ object Server extends App with LazyLogging {
         Implicits.predicateOrPredicateListDecoder(biolinkData.predicates)
 
       val example = {
-        val n0Node = TRAPIQueryNode(None, Some(List(BiolinkClass("GeneOrGeneProduct"))), None)
-        val n1Node = TRAPIQueryNode(None, Some(List(BiolinkClass("BiologicalProcess"))), None)
-        val e0Edge = TRAPIQueryEdge(Some(List(BiolinkPredicate("has_participant"))), "n1", "n0", None)
+        // This example asks what biological process or activities positively regulate GO:0004707
+        // (MAP kinase activity, see http://purl.obolibrary.org/obo/GO_0004707)
+        val n0Node = TRAPIQueryNode(None, Some(List(BiolinkClass("BiologicalProcessOrActivity"))), None)
+        val n1Node = TRAPIQueryNode(Some(List(IRI("GO:0004707"))), None, None)
+        val e0Edge = TRAPIQueryEdge(Some(List(BiolinkPredicate("positively_regulates"))), "n1", "n0", None)
         val queryGraph = TRAPIQueryGraph(Map("n0" -> n0Node, "n1" -> n1Node), Map("e0" -> e0Edge))
         val message = TRAPIMessage(Some(queryGraph), None, None)
         TRAPIQuery(message, None)

--- a/src/main/scala/org/renci/cam/Server.scala
+++ b/src/main/scala/org/renci/cam/Server.scala
@@ -104,7 +104,7 @@ object Server extends App with LazyLogging {
         // (MAP kinase activity, see http://purl.obolibrary.org/obo/GO_0004707)
         val n0Node = TRAPIQueryNode(None, Some(List(BiolinkClass("BiologicalProcessOrActivity"))), None)
         val n1Node = TRAPIQueryNode(Some(List(IRI("GO:0004707"))), None, None)
-        val e0Edge = TRAPIQueryEdge(Some(List(BiolinkPredicate("positively_regulates"))), "n1", "n0", None)
+        val e0Edge = TRAPIQueryEdge(Some(List(BiolinkPredicate("positively_regulates"))), "n0", "n1", None)
         val queryGraph = TRAPIQueryGraph(Map("n0" -> n0Node, "n1" -> n1Node), Map("e0" -> e0Edge))
         val message = TRAPIMessage(Some(queryGraph), None, None)
         TRAPIQuery(message, None)


### PR DESCRIPTION
This PR replaces the current OpenAPI example, which causes a timeout on the production server, with a new example that doesn't do this. The new query is for biological process or activities that positively regulate [GO:0004707 ("MAP kinase activity")](http://purl.obolibrary.org/obo/GO_0004707). You can see the current results [on ARAX](https://arax.ncats.io/?r=5c338267-7f6c-4bf9-9e57-6a628c7d14ea).

I couldn't initially test this locally as it would try accessing `http://localhost:8080/1.2.0/` instead of `http://localhost:8080/`, which I assume is something to do with the prefix it uses on the Kubernetes clusters. However, I could work around this by starting the server by running:

```shell
$ TRAPI_VERSION="" SPARQL_ENDPOINT="https://cam-kp-sparql.apps.renci.org/sparql" sbt "runMain org.renci.cam.Server"
```

Closes #505.