### PR TITLE
Fix IntegrationTests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -94,8 +94,8 @@ dockerExposedPorts += 8080
 // prod
 dockerEnvVars ++= Map(
   "JAVA_OPTS" -> "-Xmx16g -Xms16g -DTRAPI_VERSION=1.2.0 -DLOCATION=https://cam-kp-api.renci.org -DMATURITY=production",
-  "SPARQL_ENDPOINT" -> sys.env("SPARQL_ENDPOINT"),
-  "CAM_KP_LOG_LEVEL" -> sys.env("CAM_KP_LOG_LEVEL")
+  "SPARQL_ENDPOINT" -> sys.env.getOrElse("SPARQL_ENDPOINT", "https://cam-kp-sparql.apps.renci.org/sparql"),
+  "CAM_KP_LOG_LEVEL" -> sys.env.getOrElse("CAM_KP_LOG_LEVEL", "info")
 )
 
 dockerEntrypoint := Seq("/opt/docker/bin/server")

--- a/build.sbt
+++ b/build.sbt
@@ -21,6 +21,7 @@ javaOptions += "-Xmx8G"
 testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework")
 
 Compile / packageDoc / publishArtifact := false
+Test / fork := true
 
 configs(IntegrationTest)
 Defaults.itSettings
@@ -68,7 +69,7 @@ libraryDependencies ++= {
     "io.circe"                    %% "circe-yaml"                     % circeVersion,
     "dev.zio"                     %% "zio-test"                       % zioVersion % "it,test",
     "dev.zio"                     %% "zio-test-sbt"                   % zioVersion % "it,test",
-    "com.dimafeng"                %% "testcontainers-scala-scalatest" % "0.39.12"  % "it,test",
+    "com.dimafeng"                %% "testcontainers-scala-scalatest" % "0.40.7"  % "it,test",
     "com.google.guava"             % "guava"                          % "31.0.1-jre",
     "ch.qos.logback"               % "logback-classic"                % logbackVersion,
     "com.typesafe.scala-logging"  %% "scala-logging"                  % "3.9.4"

--- a/src/it/scala/org/renci/cam/it/BlazegraphTest.scala
+++ b/src/it/scala/org/renci/cam/it/BlazegraphTest.scala
@@ -5,6 +5,8 @@ import org.http4s.headers._
 import org.http4s.implicits._
 import org.renci.cam._
 import zio.Task
+import zio.config.getConfig
+import zio.config.typesafe.TypesafeConfig
 import zio.interop.catz._
 import zio.test.Assertion._
 import zio.test._
@@ -12,7 +14,7 @@ import zio.test.environment.testEnvironment
 
 object BlazegraphTest extends DefaultRunnableSpec {
 
-  val testLayer = (testEnvironment ++ HttpClient.makeHttpClientLayer).mapError(TestFailure.die)
+  val testLayer = (testEnvironment ++ HttpClient.makeHttpClientLayer >+> TypesafeConfig.fromDefaultLoader(AppConfig.config)).mapError(TestFailure.die)
 
   val testBlazegraphServiceDirectly = suite("testBlazegraphServiceDirectly")(
     testM("test Blazegraph service directly") {
@@ -71,8 +73,9 @@ object BlazegraphTest extends DefaultRunnableSpec {
                 LIMIT   1"""
 
       for {
+        appConfig <- getConfig[AppConfig]
         httpClient <- HttpClient.client
-        uri = uri"https://stars-app.renci.org/camdev/sparql"
+        uri = appConfig.sparqlEndpoint
           .withQueryParam("query", query)
           .withQueryParam("format", "json")
         request = Request[Task](Method.POST, uri).withHeaders(Accept(MediaType.application.json),

--- a/src/it/scala/org/renci/cam/it/MetaKnowledgeGraphServiceTest.scala
+++ b/src/it/scala/org/renci/cam/it/MetaKnowledgeGraphServiceTest.scala
@@ -2,9 +2,9 @@ package org.renci.cam.it
 
 import com.typesafe.scalalogging.LazyLogging
 import io.circe.generic.auto._
-import io.circe.{parser, Decoder, KeyDecoder, KeyEncoder}
+import io.circe.{Decoder, KeyDecoder, KeyEncoder, parser}
 import org.http4s._
-import org.http4s.headers.`Content-Type`
+import org.http4s.headers.{Accept, `Content-Type`}
 import org.http4s.implicits._
 import org.renci.cam._
 import org.renci.cam.domain.{BiolinkClass, BiolinkPredicate, MetaKnowledgeGraph}
@@ -26,8 +26,8 @@ object MetaKnowledgeGraphServiceTest extends DefaultRunnableSpec with LazyLoggin
       for {
         httpClient <- HttpClient.client
         biolinkData <- Biolink.biolinkData
-        request = Request[Task](Method.GET, uri"http://127.0.0.1:8080/meta_knowledge_graph").withHeaders(
-          `Content-Type`(MediaType.application.json))
+        request = Request[Task](Method.GET, uri"http://127.0.0.1:8080/meta_knowledge_graph")
+          .withHeaders(Accept(MediaType.application.json))
         response <- httpClient.expect[String](request)
       } yield {
         implicit val iriKeyEncoder: KeyEncoder[BiolinkClass] = Implicits.biolinkClassKeyEncoder

--- a/src/it/scala/org/renci/cam/it/ProdQueryServiceTest.scala
+++ b/src/it/scala/org/renci/cam/it/ProdQueryServiceTest.scala
@@ -35,6 +35,7 @@ object ProdQueryServiceTest extends DefaultRunnableSpec {
         trapiQuery.asJson.deepDropNullValues.noSpaces
       }
       _ = println("encoded: " + encoded)
+      // TODO: this should probably be in the AppConfig somewhere.
       uri = Uri.fromString(s"https://cam-kp-api.renci.org/${appConfig.trapiVersion}/query").toOption.get
       _ = println("uri: " + uri)
       uriWithQueryParams = uri.withQueryParam("limit", limit).withQueryParam("include_extra_edges", include_extra_edges)

--- a/src/it/scala/org/renci/cam/it/QueryServiceTest.scala
+++ b/src/it/scala/org/renci/cam/it/QueryServiceTest.scala
@@ -321,7 +321,7 @@ object QueryServiceTest extends DefaultRunnableSpec {
 
   val testDILIGeneList = suite("testDILIGeneList")(
     testM("DILIGeneList") {
-      val diliGeneList = Files.readAllLines(Paths.get("src/it/resources/dili-gene-list-alt.txt")).asScala.map(a => IRI(a.trim())).toList
+      val diliGeneList = Files.readAllLines(Paths.get("src/it/resources/dili-gene-list.txt")).asScala.map(a => IRI(a.trim())).toList
       val n0Node = TRAPIQueryNode(Some(diliGeneList), Some(List(BiolinkClass("GeneOrGeneProduct"))), None)
       val n1Node = TRAPIQueryNode(None, Some(List(BiolinkClass("GeneOrGeneProduct"))), None)
       val e0Edge = TRAPIQueryEdge(Some(List(BiolinkPredicate("affects"))), "n0", "n1", None)

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -6,7 +6,7 @@
   trapi-version = ${?TRAPI_VERSION}
   location = "http://localhost:8080"
   location = ${?LOCATION}
-  sparql-endpoint = "https://stars-app.renci.org/cam/sparql"
+  sparql-endpoint = "https://cam-kp-sparql.apps.renci.org/sparql"
   sparql-endpoint = ${?SPARQL_ENDPOINT}
   maturity = "development"
   maturity = ${?MATURITY}


### PR DESCRIPTION
Integration tests currently fail. This PR makes them all pass.

- BlazegraphTest: Replaced hardcoding of SPARQL server with config.
- QueryServiceTest: Replaced `dili-gene-list-alt.txt` to `dili-gene-list.txt`, which is the name of the file in the repository.
  - [ ] Need to make sure that this correct, see https://github.com/ExposuresProvider/cam-kp-api/pull/513/files#r875242731
- MetaKnowledgeGraphServiceTest: Fixed HTTP request.

In addition, I've added defaults for `SPARQL_ENDPOINT` (https://cam-kp-sparql.apps.renci.org/sparql) and `CAM_KP_LOG_LEVEL` (`info`).

I ran into an issue with Docker authentication while working on this PR (https://github.com/ExposuresProvider/cam-kp-api/issues/514), and upgraded `testcontainers-scala-scalatest` to `0.40.7` to try to fix it. While I managed to solve that issue by other workarounds, I've left this package at its upgraded version.