### PR TITLE
Remove include_extra_edges from /query

### DIFF
--- a/src/it/scala/org/renci/cam/it/ProdQueryServiceTest.scala
+++ b/src/it/scala/org/renci/cam/it/ProdQueryServiceTest.scala
@@ -21,8 +21,9 @@ import zio.{Has, Layer, RIO, Task, ZIO}
 
 object ProdQueryServiceTest extends DefaultRunnableSpec {
 
-  def runQuery(trapiQuery: TRAPIQuery, limit: Int = 1, include_extra_edges: Boolean = false)
-    : RIO[ZConfig[AppConfig] with HttpClient with Has[BiolinkData], (Map[IRI, TRAPINode], Map[String, TRAPIEdge])] =
+  def runQuery(
+    trapiQuery: TRAPIQuery,
+    limit: Int = 1): RIO[ZConfig[AppConfig] with HttpClient with Has[BiolinkData], (Map[IRI, TRAPINode], Map[String, TRAPIEdge])] =
     for {
       appConfig <- getConfig[AppConfig]
       httpClient <- HttpClient.client
@@ -38,7 +39,7 @@ object ProdQueryServiceTest extends DefaultRunnableSpec {
       // TODO: this should probably be in the AppConfig somewhere.
       uri = Uri.fromString(s"https://cam-kp-api.renci.org/${appConfig.trapiVersion}/query").toOption.get
       _ = println("uri: " + uri)
-      uriWithQueryParams = uri.withQueryParam("limit", limit).withQueryParam("include_extra_edges", include_extra_edges)
+      uriWithQueryParams = uri.withQueryParam("limit", limit)
       request = Request[Task](Method.POST, uriWithQueryParams)
         .withHeaders(Accept(MediaType.application.json), `Content-Type`(MediaType.application.json))
         .withEntity(encoded)

--- a/src/it/scala/org/renci/cam/it/QueryServiceTest.scala
+++ b/src/it/scala/org/renci/cam/it/QueryServiceTest.scala
@@ -22,7 +22,7 @@ import scala.jdk.CollectionConverters._
 
 object QueryServiceTest extends DefaultRunnableSpec {
 
-  def runTest(trapiQuery: TRAPIQuery, limit: Int = 1, include_extra_edges: Boolean = false): RIO[HttpClient with Has[BiolinkData], String] =
+  def runTest(trapiQuery: TRAPIQuery, limit: Int = 1): RIO[HttpClient with Has[BiolinkData], String] =
     for {
       httpClient <- HttpClient.client
       biolinkData <- Biolink.biolinkData
@@ -34,7 +34,7 @@ object QueryServiceTest extends DefaultRunnableSpec {
         trapiQuery.asJson.deepDropNullValues.noSpaces
       }
       _ = println("encoded: " + encoded)
-      uri = uri"http://127.0.0.1:8080/query".withQueryParam("limit", limit).withQueryParam("include_extra_edges", include_extra_edges)
+      uri = uri"http://127.0.0.1:8080/query".withQueryParam("limit", limit)
       request = Request[Task](Method.POST, uri)
         .withHeaders(Accept(MediaType.application.json), `Content-Type`(MediaType.application.json))
         .withEntity(encoded)

--- a/src/main/scala/org/renci/cam/QueryService.scala
+++ b/src/main/scala/org/renci/cam/QueryService.scala
@@ -256,25 +256,17 @@ object QueryService extends LazyLogging {
     *
     * @param limit
     *   The maximum number of results to return.
-    * @param includeExtraEdges
-    *   Include additional information about the returned nodes.
     * @param submittedQueryGraph
     *   The query graph to search the triplestore with.
     * @return
     *   A TRAPIMessage displaying the results.
     */
-  def run(limit: Int, includeExtraEdges: Boolean, submittedQueryGraph: TRAPIQueryGraph)
+  def run(limit: Int, submittedQueryGraph: TRAPIQueryGraph)
     : RIO[ZConfig[AppConfig] with HttpClient with Has[BiolinkData] with Has[SPARQLCache], TRAPIMessage] =
     for {
       // Get the Biolink data.
       biolinkData <- biolinkData
-      _ = logger.debug("limit: {}, includeExtraEdges: {}", limit, includeExtraEdges)
-
-      // We don't actually support `includeExtraEdges`, so if this is set, we should throw an unimplemented exception.
-      includeExtraEdgesFlag <-
-        if (includeExtraEdges)
-          ZIO.fail(new NotImplementedError("includeExtraEdges not yet supported in QueryService.run()"))
-        else ZIO.succeed(false)
+      _ = logger.debug("limit: {}", limit)
 
       // Prepare the query graph for processing.
       queryGraph = enforceQueryEdgeTypes(submittedQueryGraph, biolinkData.predicates)

--- a/src/test/scala/org/renci/cam/test/LimitTest.scala
+++ b/src/test/scala/org/renci/cam/test/LimitTest.scala
@@ -44,7 +44,7 @@ object LimitTest extends DefaultRunnableSpec with LazyLogging {
         .map(limit =>
           testM(s"Test query with limit of $limit expecting $queryGraphExpectedResults results") {
             for {
-              message <- QueryService.run(limit, false, testQueryGraph)
+              message <- QueryService.run(limit, testQueryGraph)
               _ = logger.info(s"Retrieved ${message.results.get.size} results when limit=$limit")
               results = message.results.get
             } yield {

--- a/src/test/scala/org/renci/cam/test/QueryServiceTest.scala
+++ b/src/test/scala/org/renci/cam/test/QueryServiceTest.scala
@@ -26,13 +26,6 @@ object QueryServiceTest extends DefaultRunnableSpec with LazyLogging {
   val e0Edge = TRAPIQueryEdge(None, "n1", "n0", None)
   val queryGraph = TRAPIQueryGraph(Map("n0" -> n0Node, "n1" -> n1Node), Map("e0" -> e0Edge))
 
-  /* Tests for the new QueryService.run() method. */
-  val testIncludeExtraEdges = testM("testIncludeExtraEdges") {
-    for {
-      result <- QueryService.run(100, true, queryGraph).run
-    } yield assert(result)(fails(isSubtype[NotImplementedError](anything)))
-  }
-
   /* Tests for the old QueryService.oldRun() method. These will be deleted as they are deprecated. */
 //  val testGetNodeTypes = suite("testGetNodeTypes")(
 //    testM("test get node types sans id") {
@@ -463,7 +456,6 @@ object QueryServiceTest extends DefaultRunnableSpec with LazyLogging {
   val testLayer = HttpClient.makeHttpClientLayer ++ Biolink.makeUtilitiesLayer ++ configLayer >+> SPARQLQueryExecutor.makeCache.toLayer
 
   def spec = suite("QueryService tests")(
-    testIncludeExtraEdges,
 //    testGetNodeTypes,
     testEnforceQueryEdgeTypes,
     testGetTRAPINodeBindings,


### PR DESCRIPTION
This PR removes the `include_extra_edges` parameter from the `/query` endpoint, since it is no longer supported. If we add this back in, we can restore it then.