### PR TITLE
Standardize version and add OpenAPI tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ organization := "org.renci"
 
 name := "cam-kp-api"
 
-version := "0.1.1"
+version := "0.1.2"
 
 licenses := Seq("MIT license" -> url("https://opensource.org/licenses/MIT"))
 

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ organization := "org.renci"
 
 name := "cam-kp-api"
 
-version := "0.1.2"
+version := "0.1.2-SNAPSHOT"
 
 licenses := Seq("MIT license" -> url("https://opensource.org/licenses/MIT"))
 

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,4 +1,5 @@
 {
+  version = 0.1.2
   host = 0.0.0.0
   port = 8080
   port = ${?PORT}

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,5 +1,5 @@
 {
-  version = 0.1.2
+  version = 0.1.2-SNAPSHOT
   host = 0.0.0.0
   port = 8080
   port = ${?PORT}

--- a/src/main/scala/org/renci/cam/AppConfig.scala
+++ b/src/main/scala/org/renci/cam/AppConfig.scala
@@ -4,7 +4,13 @@ import org.http4s.Uri
 import zio.config._
 import zio.config.magnolia.DeriveConfigDescriptor.{descriptor, Descriptor, _}
 
-final case class AppConfig(host: String, port: Int, location: String, sparqlEndpoint: Uri, trapiVersion: String, maturity: String)
+final case class AppConfig(host: String,
+                           port: Int,
+                           location: String,
+                           sparqlEndpoint: Uri,
+                           trapiVersion: String,
+                           maturity: String,
+                           version: String)
 
 object AppConfig {
 

--- a/src/main/scala/org/renci/cam/Server.scala
+++ b/src/main/scala/org/renci/cam/Server.scala
@@ -140,15 +140,6 @@ object Server extends App with LazyLogging {
       }
       .toRoutes
 
-  val openAPIInfo: Info = Info(
-    "CAM-KP API",
-    "0.1",
-    Some("TRAPI interface to database of Causal Activity Models"),
-    Some("https://opensource.org/licenses/MIT"),
-    Some(Contact(Some("Jim Balhoff"), Some("balhoff@renci.org"), None)),
-    Some(License("MIT License", Some("https://opensource.org/licenses/MIT")))
-  )
-
   val server: RIO[ZEnv with EndpointEnv, Unit] =
     ZIO.runtime[ZEnv with EndpointEnv].flatMap { implicit runtime =>
       for {
@@ -160,8 +151,17 @@ object Server extends App with LazyLogging {
         queryRoute = queryRouteR(queryEndpoint)
         routes = queryRoute <+> metaKnowledgeGraphRoute
         openAPI: String = OpenAPIDocsInterpreter()
-          .toOpenAPI(List(queryEndpoint, metaKnowledgeGraphEndpoint), "CAM-KP API", "0.1")
-          .copy(info = openAPIInfo)
+          .toOpenAPI(List(queryEndpoint, metaKnowledgeGraphEndpoint), "CAM-KP API", appConfig.version)
+          .copy(
+            info = Info(
+              "CAM-KP API",
+              appConfig.version,
+              Some("TRAPI interface to database of Causal Activity Models"),
+              Some("https://opensource.org/licenses/MIT"),
+              Some(Contact(Some("Jim Balhoff"), Some("balhoff@renci.org"), None)),
+              Some(License("MIT License", Some("https://opensource.org/licenses/MIT")))
+            )
+          )
           .copy(tags = List(sttp.tapir.apispec.Tag("maturity"), sttp.tapir.apispec.Tag("translator"), sttp.tapir.apispec.Tag("trapi")))
           .servers(
             List(

--- a/src/main/scala/org/renci/cam/Server.scala
+++ b/src/main/scala/org/renci/cam/Server.scala
@@ -140,41 +140,42 @@ object Server extends App with LazyLogging {
       }
       .toRoutes
 
-  val server: RIO[ZEnv with EndpointEnv, Unit] =
-    ZIO.runtime[ZEnv with EndpointEnv].flatMap { implicit runtime =>
-      for {
-        appConfig <- getConfig[AppConfig]
-        biolinkData <- biolinkData
-        metaKnowledgeGraphEndpoint <- metaKnowledgeGraphEndpointZ
-        metaKnowledgeGraphRoute = metaKnowledgeGraphRouteR(metaKnowledgeGraphEndpoint)
-        queryEndpoint <- queryEndpointZ
-        queryRoute = queryRouteR(queryEndpoint)
-        routes = queryRoute <+> metaKnowledgeGraphRoute
-        openAPI: String = OpenAPIDocsInterpreter()
-          .toOpenAPI(List(queryEndpoint, metaKnowledgeGraphEndpoint), "CAM-KP API", appConfig.version)
-          .copy(
-            info = Info(
-              "CAM-KP API",
-              appConfig.version,
-              Some("TRAPI interface to database of Causal Activity Models"),
-              Some("https://opensource.org/licenses/MIT"),
-              Some(Contact(Some("Jim Balhoff"), Some("balhoff@renci.org"), None)),
-              Some(License("MIT License", Some("https://opensource.org/licenses/MIT")))
-            )
+  /** A ZIO that produces the HttpApp object that is hosted as a server.
+    */
+  val httpApp: ZIO[ZConfig[BiolinkData] with Has[AppConfig], ParsingFailure, HttpApp[RIO[EndpointEnv, *]]] =
+    for {
+      appConfig <- getConfig[AppConfig]
+      biolinkData <- biolinkData
+      metaKnowledgeGraphEndpoint <- metaKnowledgeGraphEndpointZ
+      metaKnowledgeGraphRoute = metaKnowledgeGraphRouteR(metaKnowledgeGraphEndpoint)
+      queryEndpoint <- queryEndpointZ
+      queryRoute = queryRouteR(queryEndpoint)
+      routes = queryRoute <+> metaKnowledgeGraphRoute
+      openAPI: String = OpenAPIDocsInterpreter()
+        .toOpenAPI(List(queryEndpoint, metaKnowledgeGraphEndpoint), "CAM-KP API", appConfig.version)
+        .copy(
+          info = Info(
+            "CAM-KP API",
+            appConfig.version,
+            Some("TRAPI interface to database of Causal Activity Models"),
+            Some("https://opensource.org/licenses/MIT"),
+            Some(Contact(Some("Jim Balhoff"), Some("balhoff@renci.org"), None)),
+            Some(License("MIT License", Some("https://opensource.org/licenses/MIT")))
           )
-          .copy(tags = List(sttp.tapir.apispec.Tag("maturity"), sttp.tapir.apispec.Tag("translator"), sttp.tapir.apispec.Tag("trapi")))
-          .servers(
-            List(
-              sttp.tapir.openapi
-                .Server(s"${appConfig.location}/${appConfig.trapiVersion}")
-                .description("Default server")
-                .extensions(ListMap("x-maturity" -> ExtensionValue(s"${appConfig.maturity}"), "x-location" -> ExtensionValue("RENCI")))
-            )
+        )
+        .copy(tags = List(sttp.tapir.apispec.Tag("maturity"), sttp.tapir.apispec.Tag("translator"), sttp.tapir.apispec.Tag("trapi")))
+        .servers(
+          List(
+            sttp.tapir.openapi
+              .Server(s"${appConfig.location}/${appConfig.trapiVersion}")
+              .description("Default server")
+              .extensions(ListMap("x-maturity" -> ExtensionValue(s"${appConfig.maturity}"), "x-location" -> ExtensionValue("RENCI")))
           )
-          .toYaml
-        openAPIJson <- ZIO.fromEither(io.circe.yaml.parser.parse(openAPI))
-        info: String =
-          s"""
+        )
+        .toYaml
+      openAPIJson <- ZIO.fromEither(io.circe.yaml.parser.parse(openAPI))
+      info: String =
+        s"""
              {
                 "info": {
                   "x-translator": {
@@ -190,24 +191,32 @@ object Server extends App with LazyLogging {
                 }
              }
           """
-        infoJson <- ZIO.fromEither(io.circe.parser.parse(info))
-        openAPIinfo = infoJson.deepMerge(openAPIJson).asYaml.spaces2
-        docsRoute = ZHttp4sServerInterpreter().from(SwaggerUI[RIO[EndpointEnv, *]](openAPIinfo)).toRoutes
-        httpApp = Router("/" -> (routes <+> docsRoute)).orNotFound
-        httpAppWithLogging = Logger.httpApp(true, false)(httpApp)
-        result <-
-          BlazeServerBuilder[RIO[EndpointEnv, *]](runtime.platform.executor.asEC)
-            .bindHttp(appConfig.port, appConfig.host)
-            .withHttpApp(CORS.policy.withAllowOriginAll
-              .withAllowCredentials(false)
-              .apply(httpAppWithLogging))
-            .withResponseHeaderTimeout(120.seconds)
-            .withIdleTimeout(180.seconds)
-            .serve
-            .compile
-            .drain
-      } yield result
-    }
+      infoJson <- ZIO.fromEither(io.circe.parser.parse(info))
+      openAPIinfo = infoJson.deepMerge(openAPIJson).asYaml.spaces2
+      docsRoute = ZHttp4sServerInterpreter().from(SwaggerUI[RIO[EndpointEnv, *]](openAPIinfo)).toRoutes
+      httpApp = Router("/" -> (routes <+> docsRoute)).orNotFound
+      httpAppWithLogging = Logger.httpApp(true, false)(httpApp)
+    } yield httpAppWithLogging
+
+  /** A RIO that runs the HTTP server returned by this.httpApp until it exits.
+    */
+  val server: RIO[ZEnv with EndpointEnv, Unit] = ZIO.runtime[ZEnv with EndpointEnv].flatMap { implicit runtime =>
+    for {
+      appConfig <- getConfig[AppConfig]
+      httpApp <- httpApp
+
+      serverInstance <- BlazeServerBuilder[RIO[EndpointEnv, *]](runtime.platform.executor.asEC)
+        .bindHttp(appConfig.port, appConfig.host)
+        .withHttpApp(CORS.policy.withAllowOriginAll
+          .withAllowCredentials(false)
+          .apply(httpApp))
+        .withResponseHeaderTimeout(120.seconds)
+        .withIdleTimeout(180.seconds)
+        .serve
+        .compile
+        .drain
+    } yield serverInstance
+  }
 
   val configLayer: Layer[Throwable, ZConfig[AppConfig]] = TypesafeConfig.fromDefaultLoader(AppConfig.config)
 

--- a/src/test/scala/org/renci/cam/test/OpenAPITest.scala
+++ b/src/test/scala/org/renci/cam/test/OpenAPITest.scala
@@ -25,11 +25,24 @@ object OpenAPITest extends DefaultRunnableSpec with LazyLogging {
 
         // Look up info.version.
         infoVersionOpt = openApiDoc.hcursor.downField("info").downField("version").as[String].toOption
+
+        // Look up info.x-trapi.version
+        infoXTrapiVersion = openApiDoc.hcursor.downField("info").downField("x-trapi").downField("version").as[String].toOption
+
+        // Look up servers[0] url and x-maturity.
+        servers0Url = openApiDoc.hcursor.downField("servers").downN(0).downField("url").as[String].toOption
+        servers0XMaturity = openApiDoc.hcursor.downField("servers").downN(0).downField("x-maturity").as[String].toOption
+
       } yield assert(response.status)(Assertion.equalTo(Status.Ok)) &&
         assert(content)(Assertion.isNonEmptyString) &&
         // Check the info.version value.
         assert(infoVersionOpt)(Assertion.isSome(Assertion.isNonEmptyString)) &&
-        assert(infoVersionOpt)(Assertion.equalTo(Some(appConfig.version)))
+        assert(infoVersionOpt)(Assertion.equalTo(Some(appConfig.version))) &&
+        // Check info.x-trapi.version.
+        assert(infoXTrapiVersion)(Assertion.equalTo(Some(appConfig.trapiVersion))) &&
+        // Check servers[0].
+        assert(servers0Url)(Assertion.equalTo(Some(appConfig.location + '/' + appConfig.trapiVersion))) &&
+        assert(servers0XMaturity)(Assertion.equalTo(Some(appConfig.maturity)))
     }
   }
 

--- a/src/test/scala/org/renci/cam/test/OpenAPITest.scala
+++ b/src/test/scala/org/renci/cam/test/OpenAPITest.scala
@@ -1,0 +1,37 @@
+package org.renci.cam.test
+
+import cats.implicits._
+import com.typesafe.scalalogging.LazyLogging
+import io.circe.yaml.parser
+import org.http4s.{EntityDecoder, Request, Status, Uri}
+import org.renci.cam._
+import org.renci.cam.domain._
+import zio.config.ZConfig
+import zio.config.typesafe.TypesafeConfig
+import zio.interop.catz.concurrentInstance
+import zio.test._
+import zio.{Layer, ZIO}
+
+object OpenAPITest extends DefaultRunnableSpec with LazyLogging {
+  // implicit val F = Concurrent[IO]
+
+  val testOpenAPISpecification = suite("testOpenAPISpecification") {
+    testM("Validate and check Open API specification") {
+      for {
+        server <- Server.httpApp
+        response <- server(Request(uri = Uri.unsafeFromString("/docs/docs.yaml")))
+        content <- EntityDecoder.decodeText(response)
+        openApiDoc <- ZIO.fromEither(parser.parse(content))
+      } yield assert(response.status)(Assertion.equalTo(Status.Ok)) &&
+        assert(content)(Assertion.isNonEmptyString)
+    }
+  }
+
+  val configLayer: Layer[Throwable, ZConfig[AppConfig]] = TypesafeConfig.fromDefaultLoader(AppConfig.config)
+  val testLayer = HttpClient.makeHttpClientLayer ++ Biolink.makeUtilitiesLayer ++ configLayer >+> SPARQLQueryExecutor.makeCache.toLayer
+
+  def spec = suite("OpenAPI tests")(
+    testOpenAPISpecification
+  ).provideCustomLayer(testLayer.mapError(TestFailure.die))
+
+}


### PR DESCRIPTION
This PR consolidates all mentions of the CAM-KP-API version into two locations: `build.sbt` and `src/main/resource/application.conf`.

In order to check that this worked, I tweaked Server so that the HTTPApp can be accessed without running it, and then wrote some tests to make sure that the generated OpenAPI YAML output correctly provides the CAM-KP API version, TRAPI version, server URL and server maturity.