### PR TITLE
Add example queries test

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,14 @@ CAMs (Causal Activity Models) are small knowledge graphs built using the [Web On
 ## Issue Management
 
 Anyone can create new issues by clicking on "New issue" button on the [issues](https://github.com/NCATS-Tangerine/cam-kp-api/issues) page of this repository. Click here for the [current issues](https://github.com/NCATS-Tangerine/cam-kp-api/issues).
+
+## Example queries
+
+Example queries are included in [./src/it/resources/examples](./src/it/resources/examples).
+Look for the `message` field in each JSON file in that directory. You can run them by running:
+
+```shell
+$ CAM_KP_ENDPOINT=https://cam-kp-api-dev.renci.org/1.2.0/query sbt "IntegrationTest/testOnly org.renci.cam.it.ExampleQueriesEndpointTest"
+```
+
+Server responses will be written to the `./src/it/resources/example-results` directory.

--- a/src/it/resources/.gitignore
+++ b/src/it/resources/.gitignore
@@ -1,0 +1,1 @@
+/example-results

--- a/src/it/resources/examples/genes-upstream-of-GPR35.json
+++ b/src/it/resources/examples/genes-upstream-of-GPR35.json
@@ -1,0 +1,33 @@
+{
+  "description": "Find genes causally upstream of the activity of ‘GPR35’, specifically occurring within leukocytes (CL:0000738)",
+  "message": {
+    "query_graph": {
+      "nodes": {
+        "n0": {
+          "categories": ["biolink:GeneOrGeneProduct"]
+        },
+        "n1": {
+          "categories": ["biolink:GeneOrGeneProduct"],
+          "ids": ["UniProtKB:Q9HC97"]
+        },
+        "n2": {
+          "categories": ["biolink:AnatomicalEntity"],
+          "ids": ["CL:0000738"]
+        }
+      },
+      "edges": {
+        "e0": {
+          "subject": "n0",
+          "object": "n1",
+          "predicates": ["biolink:affects_activity_of"]
+        },
+        "e1": {
+          "subject": "n1",
+          "object": "n2",
+          "predicates": ["biolink:part_of"]
+        }
+      }
+    }
+  },
+  "minExpectedResults": 6
+}

--- a/src/it/resources/examples/simple.json
+++ b/src/it/resources/examples/simple.json
@@ -1,0 +1,23 @@
+{
+  "description": "A simple query to test a CAM-KP-API endpoint.",
+  "message": {
+    "query_graph": {
+      "nodes": {
+        "n0": {
+          "categories": ["biolink:GeneOrGeneProduct"]
+        },
+        "n1": {
+          "categories": ["biolink:AnatomicalEntity"],
+          "ids": ["GO:0005634"]
+        }
+      },
+      "edges": {
+        "e0": {
+          "subject": "n0",
+          "object": "n1",
+          "predicates": ["biolink:part_of"]
+        }
+      }
+    }
+  }
+}

--- a/src/it/resources/examples/simple.json
+++ b/src/it/resources/examples/simple.json
@@ -20,5 +20,6 @@
       }
     }
   },
-  "minExpectedResults": 34
+  "minExpectedResults": 34,
+  "maxExpectedResults": 34
 }

--- a/src/it/resources/examples/simple.json
+++ b/src/it/resources/examples/simple.json
@@ -20,6 +20,6 @@
       }
     }
   },
-  "minExpectedResults": 34,
-  "maxExpectedResults": 34
+  "minExpectedResults": 160,
+  "maxExpectedResults": 160
 }

--- a/src/it/resources/examples/simple.json
+++ b/src/it/resources/examples/simple.json
@@ -19,5 +19,6 @@
         }
       }
     }
-  }
+  },
+  "minExpectedResults": 34
 }

--- a/src/it/resources/examples/swagger-example.json
+++ b/src/it/resources/examples/swagger-example.json
@@ -1,0 +1,29 @@
+{
+  "description": "The query used as our example query in Swagger",
+  "message": {
+    "query_graph": {
+      "nodes": {
+        "n0": {
+          "categories": [
+            "biolink:BiologicalProcessOrActivity"
+          ]
+        },
+        "n1": {
+          "ids": [
+            "GO:0004707"
+          ]
+        }
+      },
+      "edges": {
+        "e0": {
+          "predicates": [
+            "biolink:positively_regulates"
+          ],
+          "subject": "n0",
+          "object": "n1"
+        }
+      }
+    }
+  },
+  "minExpectedResults": 34
+}

--- a/src/it/resources/examples/things-related-to-pyruvate.json
+++ b/src/it/resources/examples/things-related-to-pyruvate.json
@@ -1,0 +1,24 @@
+{
+  "description": "Named things related to pyruvate (CHEBI:15361)",
+  "message": {
+    "query_graph": {
+      "nodes": {
+        "n0": {
+          "ids": ["http://purl.obolibrary.org/obo/CHEBI_15361"]
+        },
+        "n1": {
+          "categories": ["biolink:NamedThing"]
+        }
+      },
+      "edges": {
+        "e0": {
+          "subject": "n0",
+          "object": "n1",
+          "predicates": ["biolink:related_to"]
+        }
+      }
+    }
+  },
+  "limit": 100000,
+  "minExpectedResults": 1035
+}

--- a/src/it/resources/examples/things-related-to-valproic-acid.json
+++ b/src/it/resources/examples/things-related-to-valproic-acid.json
@@ -1,0 +1,23 @@
+{
+  "description": "Named things related to valproic acid (CHEBI:39867)",
+  "message": {
+    "query_graph": {
+      "nodes": {
+        "n0": {
+          "ids": ["http://purl.obolibrary.org/obo/CHEBI_39867"]
+        },
+        "n1": {
+          "categories": ["biolink:NamedThing"]
+        }
+      },
+      "edges": {
+        "e0": {
+          "subject": "n0",
+          "object": "n1",
+          "predicates": ["biolink:related_to"]
+        }
+      }
+    }
+  },
+  "minExpectedResults": 9
+}

--- a/src/it/resources/examples/within-the-cytoplasm.json
+++ b/src/it/resources/examples/within-the-cytoplasm.json
@@ -1,0 +1,24 @@
+{
+  "description": "Molecular activities occuring within the cytoplasm",
+  "message": {
+    "query_graph": {
+      "nodes": {
+        "n0": {
+          "categories": ["biolink:BiologicalProcessOrActivity"]
+        },
+        "n1": {
+          "categories": ["biolink:AnatomicalEntity"],
+          "ids": ["GO:0005737"]
+        }
+      },
+      "edges": {
+        "e0": {
+          "subject": "n0",
+          "object": "n1",
+          "predicates": ["biolink:occurs_in"]
+        }
+      }
+    }
+  },
+  "minExpectedResults": 38
+}

--- a/src/it/scala/org/renci/cam/it/ExampleQueriesEndpointTest.scala
+++ b/src/it/scala/org/renci/cam/it/ExampleQueriesEndpointTest.scala
@@ -63,12 +63,13 @@ object ExampleQueriesEndpointTest extends DefaultRunnableSpec {
               // Read the example JSON file.
               exampleJson <- ZIO.fromEither(io.circe.parser.parse(exampleText))
               descriptionOpt = exampleJson.hcursor.downField("description").as[String].toOption
+              limit = exampleJson.hcursor.downField("limit").as[Long].toOption.getOrElse(0)
               minExpectedResultsOpt = exampleJson.hcursor.downField("minExpectedResults").as[Int].toOption
               maxExpectedResultsOpt = exampleJson.hcursor.downField("maxExpectedResults").as[Int].toOption
               messageText <- ZIO.fromEither(exampleJson.hcursor.downField("message").as[Json].map(_.noSpaces))
 
               // Prepare request for the CAM-KP-API endpoint.
-              request = Request[Task](Method.POST, endpointToTest)
+              request = Request[Task](Method.POST, endpointToTest.withQueryParam("limit", limit.toString))
                 .withHeaders(Accept(MediaType.application.json), `Content-Type`(MediaType.application.json))
                 .withEntity("{\"message\": " + messageText + "}")
               response <- httpClient.expect[Json](request)

--- a/src/it/scala/org/renci/cam/it/ExampleQueriesEndpointTest.scala
+++ b/src/it/scala/org/renci/cam/it/ExampleQueriesEndpointTest.scala
@@ -24,6 +24,9 @@ import java.nio.file.{Files, Path, Paths}
 import scala.io.Source
 import scala.jdk.CollectionConverters._
 
+/** Run example queries against a CAM-KP-API endpoint, writing the responses out in `src/it/resources/example-results` and then testing the
+  * expectations described in the example file.
+  */
 object ExampleQueriesEndpointTest extends DefaultRunnableSpec {
   val exampleDir: Path = Paths.get("src/it/resources/examples")
   val exampleResultsDir: Path = Paths.get("src/it/resources/example-results")

--- a/src/it/scala/org/renci/cam/it/ExampleQueriesEndpointTest.scala
+++ b/src/it/scala/org/renci/cam/it/ExampleQueriesEndpointTest.scala
@@ -10,7 +10,7 @@ import org.http4s.headers.{`Content-Type`, Accept}
 import org.http4s.implicits._
 import org.renci.cam.Biolink.biolinkData
 import org.renci.cam.HttpClient.HttpClient
-import org.renci.cam.domain.{BiolinkClass, BiolinkPredicate, IRI, TRAPIAttribute, TRAPIMessage, TRAPIResponse}
+import org.renci.cam.domain.{BiolinkClass, BiolinkPredicate, IRI, TRAPIAttribute, TRAPIMessage, TRAPIQuery, TRAPIResponse}
 import org.renci.cam.{AppConfig, Biolink, HttpClient, Implicits}
 import zio.blocking.Blocking
 import zio.config.ZConfig
@@ -27,6 +27,8 @@ import scala.jdk.CollectionConverters._
 
 /** Run example queries against a CAM-KP-API endpoint, writing the responses out in `src/it/resources/example-results` and then testing the
   * expectations described in the example file.
+  *
+  * The endpoint is read from the environmental variable CAM_KP_ENDPOINT; otherwise, we default to the RENCI prod instance.
   */
 object ExampleQueriesEndpointTest extends DefaultRunnableSpec {
   val exampleDir: Path = Paths.get("src/it/resources/examples")
@@ -97,8 +99,9 @@ object ExampleQueriesEndpointTest extends DefaultRunnableSpec {
                 implicit val biolinkPredicateEncoder: Encoder[BiolinkPredicate] =
                   Implicits.biolinkPredicateEncoder(biolinkData.prefixes)
 
-                example.message.asJson.deepDropNullValues.noSpaces
+                TRAPIQuery(message = example.message, log_level = None).asJson.deepDropNullValues.noSpaces
               }
+              // _ = println(s"messageText = ${messageText}")
               request = Request[Task](Method.POST, endpointToTest.withQueryParam("limit", limit.toString))
                 .withHeaders(Accept(MediaType.application.json), `Content-Type`(MediaType.application.json))
                 .withEntity(messageText)

--- a/src/it/scala/org/renci/cam/it/ExampleQueriesTest.scala
+++ b/src/it/scala/org/renci/cam/it/ExampleQueriesTest.scala
@@ -37,8 +37,9 @@ object ExampleQueriesTest extends DefaultRunnableSpec {
             }
             for {
               exampleJson <- ZIO.fromEither(parser.parse(exampleText))
-              descriptions = exampleJson \\ "description"
-            } yield assert(descriptions)(hasSize(equalTo(1))) && assert(descriptions.head.asString)(isSome(isNonEmptyString))
+              descriptionOpt = exampleJson.hcursor.downField("description").as[String].toOption
+              messageText <- ZIO.fromEither(exampleJson.hcursor.downField("message").as[Json].map(_.noSpaces))
+            } yield assert(descriptionOpt)(isSome(isNonEmptyString)) && assert(messageText)(isNonEmptyString)
           })
         .runCollect
     }

--- a/src/it/scala/org/renci/cam/it/ExampleQueriesTest.scala
+++ b/src/it/scala/org/renci/cam/it/ExampleQueriesTest.scala
@@ -1,14 +1,23 @@
 package org.renci.cam.it
 
 import io.circe._
-import org.renci.cam.{AppConfig, Biolink, HttpClient}
+import io.circe.generic.auto._
+import io.circe.generic.semiauto._
+import org.http4s._
+import org.http4s.circe.CirceEntityCodec.circeEntityDecoder
+import org.http4s.headers.{`Content-Type`, Accept}
+import org.http4s.implicits._
+import org.renci.cam.Biolink.biolinkData
+import org.renci.cam.domain.{BiolinkClass, BiolinkPredicate, IRI, TRAPIAttribute, TRAPIResponse}
+import org.renci.cam.{AppConfig, Biolink, HttpClient, Implicits}
 import zio.blocking.Blocking
 import zio.config.ZConfig
 import zio.config.typesafe.TypesafeConfig
+import zio.interop.catz._
 import zio.stream.ZStream
 import zio.test.Assertion._
 import zio.test._
-import zio.{Layer, ZIO}
+import zio.{Layer, Task, ZIO}
 
 import java.nio.file.{Files, Paths}
 import scala.io.Source
@@ -16,6 +25,8 @@ import scala.jdk.CollectionConverters._
 
 object ExampleQueriesTest extends DefaultRunnableSpec {
   val exampleDir = Paths.get("src/it/resources/examples")
+
+  val endpointToTest = uri"https://cam-kp-api.renci.org/1.2.0/query"
 
   val testEachExampleFile = {
     // List of example files to process.
@@ -36,10 +47,32 @@ object ExampleQueriesTest extends DefaultRunnableSpec {
               source.getLines().mkString("\n")
             }
             for {
-              exampleJson <- ZIO.fromEither(parser.parse(exampleText))
+              httpClient <- HttpClient.client
+              biolinkData <- biolinkData
+
+              exampleJson <- ZIO.fromEither(io.circe.parser.parse(exampleText))
               descriptionOpt = exampleJson.hcursor.downField("description").as[String].toOption
               messageText <- ZIO.fromEither(exampleJson.hcursor.downField("message").as[Json].map(_.noSpaces))
-            } yield assert(descriptionOpt)(isSome(isNonEmptyString)) && assert(messageText)(isNonEmptyString)
+              request = Request[Task](Method.POST, endpointToTest)
+                .withHeaders(Accept(MediaType.application.json), `Content-Type`(MediaType.application.json))
+                .withEntity("{\"message\": " + messageText + "}")
+              response <- httpClient.expect[Json](request)
+              trapiResponse <- ZIO.fromEither(
+                {
+                  implicit val decoderIRI: Decoder[IRI] = Implicits.iriDecoder(biolinkData.prefixes)
+                  implicit val keyDecoderIRI: KeyDecoder[IRI] = Implicits.iriKeyDecoder(biolinkData.prefixes)
+                  implicit val decoderBiolinkClass: Decoder[BiolinkClass] = Implicits.biolinkClassDecoder(biolinkData.classes)
+                  implicit val decoderBiolinkPredicate: Decoder[BiolinkPredicate] =
+                    Implicits.biolinkPredicateDecoder(biolinkData.predicates)
+                  implicit val decoderTRAPIAttribute: Decoder[TRAPIAttribute] = deriveDecoder[TRAPIAttribute]
+
+                  response.as[TRAPIResponse]
+                }
+              )
+              _ = println("response: " + response)
+            } yield assert(descriptionOpt)(isSome(isNonEmptyString)) &&
+              assert(messageText)(isNonEmptyString) &&
+              assert(trapiResponse.status)(isSome(equalTo("Success")))
           })
         .runCollect
     }

--- a/src/it/scala/org/renci/cam/it/ExampleQueriesTest.scala
+++ b/src/it/scala/org/renci/cam/it/ExampleQueriesTest.scala
@@ -1,0 +1,55 @@
+package org.renci.cam.it
+
+import io.circe._
+import org.renci.cam.{AppConfig, Biolink, HttpClient}
+import zio.blocking.Blocking
+import zio.config.ZConfig
+import zio.config.typesafe.TypesafeConfig
+import zio.stream.ZStream
+import zio.test.Assertion._
+import zio.test._
+import zio.{Layer, ZIO}
+
+import java.nio.file.{Files, Paths}
+import scala.io.Source
+import scala.jdk.CollectionConverters._
+
+object ExampleQueriesTest extends DefaultRunnableSpec {
+  val exampleDir = Paths.get("src/it/resources/examples")
+
+  val testEachExampleFile = {
+    // List of example files to process.
+    val exampleFiles = Files
+      .walk(exampleDir)
+      .iterator()
+      .asScala
+      .filter(Files.isRegularFile(_))
+      .toSeq
+
+    suiteM("Test example files in the src/it/resources/examples directory") {
+      ZStream
+        .fromIterable(exampleFiles)
+        .map(exampleFile =>
+          testM(s"Testing ${exampleDir.relativize(exampleFile)}") {
+            val exampleText = {
+              val source = Source.fromFile(exampleFile.toFile)
+              source.getLines().mkString("\n")
+            }
+            for {
+              exampleJson <- ZIO.fromEither(parser.parse(exampleText))
+              descriptions = exampleJson \\ "description"
+            } yield assert(descriptions)(hasSize(equalTo(1))) && assert(descriptions.head.asString)(isSome(isNonEmptyString))
+          })
+        .runCollect
+    }
+  }
+
+  val configLayer: Layer[Throwable, ZConfig[AppConfig]] = TypesafeConfig.fromDefaultLoader(AppConfig.config)
+  val camkpapiLayer = Blocking.live >>> HttpClient.makeHttpClientLayer >+> Biolink.makeUtilitiesLayer
+  val testLayer = (configLayer ++ camkpapiLayer).mapError(TestFailure.die)
+
+  def spec = suite("ExampleQueriesTest")(
+    testEachExampleFile
+  ).provideCustomLayer(testLayer)
+
+}


### PR DESCRIPTION
This PR is intended to make it easier to test a number of queries against a CAM-KP-API server and to check that we get back the expected results, by:
1. Creating a `src/it/resources/examples` directory that can contain any number of JSON files in any number of directories. These JSON documents should contain a number of fields:
   - "description": A description of the test
   - "message" (required): The TRAPI message to send to the server
   - "minExpectedResults": the minimum number of results we expect
   - "maxExpectedResults": the maximum number of results we expect
2. Creating a `org.renci.cam.it.ExampleQueriesTest`  integration test which runs these tests and ensures that successful 
   - By default, this tests the production endpoint at `https://cam-kp-api.renci.org/1.2.0/query`, but the `CAM_KP_ENDPOINT` environmental variable can be set an alternate endpoint location.
3. To aid with debugging, the responses to the example directories will be written into the `src/it/resources/example-results` directory.

This PR includes four example files: the [three example queries from the wiki](https://github.com/ExposuresProvider/cam-kp-api/wiki/Example-Queries), the query we use as a Swagger example, a query ("named things related to valproic acid") that will return both CTD and GO-CAM results, and a query ("named things related to pyruvate") that returns both SIGNOR and GO-CAM results.

In a future PR I'll add some actual validation of the results by (1) doing some content checks (e.g. making sure that every node and edge binding refers to nodes and edges actually in the message, checking for duplicate results, and so on) and (2) by writing down some test triples as is being done in the [Translator testing repository](https://github.com/NCATSTranslator/testing/blob/848e8dabd94421ee41b44565ade9050b50bae475/onehop/test_triples/KP/Exposures_Provider/CAM-KP_API.json)), but for now, this PR lets us quickly add new queries to our list of tests and lets us look at all the query results to see what the server is returning.