### PR TITLE
Update TRAPI model to 1.3

### DIFF
--- a/src/it/scala/org/renci/cam/it/ExampleQueriesEndpointTest.scala
+++ b/src/it/scala/org/renci/cam/it/ExampleQueriesEndpointTest.scala
@@ -80,7 +80,7 @@ object ExampleQueriesEndpointTest extends DefaultRunnableSpec {
                   implicit val decoderBiolinkClass: Decoder[BiolinkClass] = Implicits.biolinkClassDecoder(biolinkData.classes)
                   implicit val decoderBiolinkPredicate: Decoder[BiolinkPredicate] =
                     Implicits.biolinkPredicateDecoder(biolinkData.predicates)
-                  implicit val decoderTRAPIAttribute: Decoder[TRAPIAttribute] = deriveDecoder[TRAPIAttribute]
+                  implicit lazy val decoderTRAPIAttribute: Decoder[TRAPIAttribute] = deriveDecoder[TRAPIAttribute]
 
                   exampleJson.as[ExampleJsonFile]
                 }
@@ -120,7 +120,7 @@ object ExampleQueriesEndpointTest extends DefaultRunnableSpec {
                   implicit val decoderBiolinkClass: Decoder[BiolinkClass] = Implicits.biolinkClassDecoder(biolinkData.classes)
                   implicit val decoderBiolinkPredicate: Decoder[BiolinkPredicate] =
                     Implicits.biolinkPredicateDecoder(biolinkData.predicates)
-                  implicit val decoderTRAPIAttribute: Decoder[TRAPIAttribute] = deriveDecoder[TRAPIAttribute]
+                  implicit lazy val decoderTRAPIAttribute: Decoder[TRAPIAttribute] = deriveDecoder[TRAPIAttribute]
 
                   response.as[TRAPIResponse]
                 }

--- a/src/it/scala/org/renci/cam/it/ProdQueryServiceTest.scala
+++ b/src/it/scala/org/renci/cam/it/ProdQueryServiceTest.scala
@@ -60,7 +60,7 @@ object ProdQueryServiceTest extends DefaultRunnableSpec {
         implicit val decoderIRI: Decoder[IRI] = Implicits.iriDecoder(biolinkData.prefixes)
         implicit val keyDecoderIRI: KeyDecoder[IRI] = Implicits.iriKeyDecoder(biolinkData.prefixes)
         implicit val decoderTRAPINode: Decoder[BiolinkClass] = Implicits.biolinkClassDecoder(biolinkData.classes)
-        implicit val decoderTRAPIAttribute: Decoder[TRAPIAttribute] = deriveDecoder[TRAPIAttribute]
+        implicit lazy val decoderTRAPIAttribute: Decoder[TRAPIAttribute] = deriveDecoder[TRAPIAttribute]
         knowledgeGraphNodesJson.as[Map[IRI, TRAPINode]]
       }
 
@@ -76,7 +76,7 @@ object ProdQueryServiceTest extends DefaultRunnableSpec {
         implicit val keyDecoderIRI: KeyDecoder[IRI] = Implicits.iriKeyDecoder(biolinkData.prefixes)
         implicit val decoderBiolinkClass: Decoder[BiolinkClass] = Implicits.biolinkClassDecoder(biolinkData.classes)
         implicit val decoderBiolinkPredicate: Decoder[BiolinkPredicate] = Implicits.biolinkPredicateDecoder(biolinkData.predicates)
-        implicit val decoderTRAPIAttribute: Decoder[TRAPIAttribute] = deriveDecoder[TRAPIAttribute]
+        implicit lazy val decoderTRAPIAttribute: Decoder[TRAPIAttribute] = deriveDecoder[TRAPIAttribute]
         knowledgeGraphEdgesJson.as[Map[String, TRAPIEdge]]
       }
 

--- a/src/it/scala/org/renci/cam/it/TestContainer.scala
+++ b/src/it/scala/org/renci/cam/it/TestContainer.scala
@@ -12,7 +12,7 @@ object TestContainer {
   def camkpapi: ZLayer[Blocking, Nothing, CAMKPAPI] =
     ZManaged.make {
       effectBlocking {
-        val container = FixedHostPortGenericContainer("renciorg/cam-kp-api:0.1",
+        val container = FixedHostPortGenericContainer("renciorg/cam-kp-api:0.1.3-SNAPSHOT",
                                                       exposedHostPort = 8080,
                                                       exposedContainerPort = 8080,
                                                       waitStrategy = Wait.forHttp("/meta_knowledge_graph"))

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -3,7 +3,7 @@
   host = 0.0.0.0
   port = 8080
   port = ${?PORT}
-  trapi-version = "1.2.0"
+  trapi-version = "1.3"
   trapi-version = ${?TRAPI_VERSION}
   location = "http://localhost:8080"
   location = ${?LOCATION}

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -3,7 +3,7 @@
   host = 0.0.0.0
   port = 8080
   port = ${?PORT}
-  trapi-version = "1.3"
+  trapi-version = "1.3.0"
   trapi-version = ${?TRAPI_VERSION}
   location = "http://localhost:8080"
   location = ${?LOCATION}

--- a/src/main/scala/org/renci/cam/domain/package.scala
+++ b/src/main/scala/org/renci/cam/domain/package.scala
@@ -131,7 +131,8 @@ package object domain {
   final case class TRAPIQueryEdge(predicates: Option[List[BiolinkPredicate]],
                                   subject: String,
                                   `object`: String,
-                                  constraints: Option[List[TRAPIQueryConstraint]])
+                                  constraints: Option[List[TRAPIQueryConstraint]],
+                                  knowledge_type: Option[String] = None)
 
   final case class TRAPIQueryConstraint(id: IRI,
                                         name: String,

--- a/src/main/scala/org/renci/cam/domain/package.scala
+++ b/src/main/scala/org/renci/cam/domain/package.scala
@@ -181,7 +181,7 @@ package object domain {
                                 knowledge_graph: Option[TRAPIKnowledgeGraph],
                                 results: Option[List[TRAPIResult]])
 
-  final case class TRAPIQuery(message: TRAPIMessage, log_level: Option[String])
+  final case class TRAPIQuery(message: TRAPIMessage, log_level: Option[String], submitter: Option[String])
 
   final case class TRAPIResponse(message: TRAPIMessage, status: Option[String], description: Option[String], logs: Option[List[LogEntry]])
 

--- a/src/main/scala/org/renci/cam/domain/package.scala
+++ b/src/main/scala/org/renci/cam/domain/package.scala
@@ -154,15 +154,7 @@ package object domain {
                                   value_type_id: Option[IRI],
                                   value_url: Option[String],
                                   description: Option[String],
-                                  attributes: Option[List[TRAPISubAttribute]])
-
-  final case class TRAPISubAttribute(attribute_source: Option[String],
-                                     attribute_type_id: IRI,
-                                     original_attribute_name: Option[String],
-                                     value: List[String],
-                                     value_type_id: Option[IRI],
-                                     value_url: Option[String],
-                                     description: Option[String])
+                                  attributes: Option[List[TRAPIAttribute]])
 
   final case class TRAPIKnowledgeGraph(nodes: Map[IRI, TRAPINode], edges: Map[String, TRAPIEdge])
 

--- a/src/main/scala/org/renci/cam/domain/package.scala
+++ b/src/main/scala/org/renci/cam/domain/package.scala
@@ -139,12 +139,12 @@ package object domain {
                                   qualifier_constraints: Option[List[TRAPIQualifierConstraint]] = None)
 
   final case class TRAPIAttributeConstraint(id: IRI,
-                                        name: String,
-                                        not: Option[Boolean],
-                                        operator: String,
-                                        value: String,
-                                        unit_id: Option[IRI],
-                                        unit_name: Option[String])
+                                            name: String,
+                                            not: Option[Boolean],
+                                            operator: String,
+                                            value: String,
+                                            unit_id: Option[IRI],
+                                            unit_name: Option[String])
 
   final case class TRAPIQueryGraph(nodes: Map[String, TRAPIQueryNode], edges: Map[String, TRAPIQueryEdge])
 

--- a/src/main/scala/org/renci/cam/domain/package.scala
+++ b/src/main/scala/org/renci/cam/domain/package.scala
@@ -171,7 +171,7 @@ package object domain {
 
   }
 
-  final case class TRAPINodeBinding(id: IRI, query_id: IRI, attributes: Option[List[TRAPIAttribute]])
+  final case class TRAPINodeBinding(id: IRI, query_id: Option[IRI] = None, attributes: Option[List[TRAPIAttribute]] = None)
 
   final case class TRAPIEdgeBinding(id: String)
 

--- a/src/main/scala/org/renci/cam/domain/package.scala
+++ b/src/main/scala/org/renci/cam/domain/package.scala
@@ -171,7 +171,7 @@ package object domain {
 
   }
 
-  final case class TRAPINodeBinding(id: IRI)
+  final case class TRAPINodeBinding(id: IRI, query_id: IRI, attributes: Option[List[TRAPIAttribute]])
 
   final case class TRAPIEdgeBinding(id: String)
 

--- a/src/main/scala/org/renci/cam/domain/package.scala
+++ b/src/main/scala/org/renci/cam/domain/package.scala
@@ -126,15 +126,19 @@ package object domain {
 
   }
 
-  final case class TRAPIQueryNode(ids: Option[List[IRI]], categories: Option[List[BiolinkClass]], is_set: Option[Boolean])
+  final case class TRAPIQueryNode(ids: Option[List[IRI]],
+                                  categories: Option[List[BiolinkClass]],
+                                  is_set: Option[Boolean] = Some(false),
+                                  constraints: List[TRAPIAttributeConstraint] = List())
 
   final case class TRAPIQueryEdge(predicates: Option[List[BiolinkPredicate]],
                                   subject: String,
                                   `object`: String,
-                                  constraints: Option[List[TRAPIQueryConstraint]],
-                                  knowledge_type: Option[String] = None)
+                                  knowledge_type: Option[String] = None,
+                                  attribute_constraints: Option[List[TRAPIAttributeConstraint]],
+                                  qualifier_constraints: Option[List[TRAPIQualifierConstraint]])
 
-  final case class TRAPIQueryConstraint(id: IRI,
+  final case class TRAPIAttributeConstraint(id: IRI,
                                         name: String,
                                         not: Option[Boolean],
                                         operator: String,
@@ -146,7 +150,11 @@ package object domain {
 
   final case class TRAPINode(name: Option[String], categories: Option[List[BiolinkClass]], attributes: Option[List[TRAPIAttribute]])
 
-  final case class TRAPIEdge(predicate: Option[BiolinkPredicate], subject: IRI, `object`: IRI, attributes: Option[List[TRAPIAttribute]])
+  final case class TRAPIEdge(predicate: Option[BiolinkPredicate],
+                             subject: IRI,
+                             `object`: IRI,
+                             attributes: Option[List[TRAPIAttribute]],
+                             qualifiers: Option[List[TRAPIQualifier]])
 
   final case class TRAPIAttribute(attribute_source: Option[String],
                                   attribute_type_id: IRI,
@@ -160,6 +168,10 @@ package object domain {
                                   value_url: Option[String],
                                   description: Option[String],
                                   attributes: Option[List[TRAPIAttribute]])
+
+  final case class TRAPIQualifier(qualifier_type_id: String, qualifier_value: String)
+
+  final case class TRAPIQualifierConstraint(qualifier_set: List[TRAPIQualifier])
 
   final case class TRAPIKnowledgeGraph(nodes: Map[IRI, TRAPINode], edges: Map[String, TRAPIEdge])
 

--- a/src/main/scala/org/renci/cam/domain/package.scala
+++ b/src/main/scala/org/renci/cam/domain/package.scala
@@ -129,7 +129,7 @@ package object domain {
   final case class TRAPIQueryNode(ids: Option[List[IRI]],
                                   categories: Option[List[BiolinkClass]],
                                   is_set: Option[Boolean] = Some(false),
-                                  constraints: List[TRAPIAttributeConstraint] = List())
+                                  constraints: Option[List[TRAPIAttributeConstraint]] = None)
 
   final case class TRAPIQueryEdge(predicates: Option[List[BiolinkPredicate]],
                                   subject: String,

--- a/src/main/scala/org/renci/cam/domain/package.scala
+++ b/src/main/scala/org/renci/cam/domain/package.scala
@@ -150,6 +150,10 @@ package object domain {
   final case class TRAPIAttribute(attribute_source: Option[String],
                                   attribute_type_id: IRI,
                                   original_attribute_name: Option[String],
+                                  // Note that `value` is actually supposed to be able to support
+                                  // any data type, including lists.
+                                  // https://github.com/NCATSTranslator/ReasonerAPI/blob/7520ac564e63289dffe092d4c7affd6db4ba22f1/TranslatorReasonerAPI.yaml#L761-L764
+                                  // Not sure if a List[String] is close enough to read attributes here.
                                   value: List[String],
                                   value_type_id: Option[IRI],
                                   value_url: Option[String],

--- a/src/main/scala/org/renci/cam/domain/package.scala
+++ b/src/main/scala/org/renci/cam/domain/package.scala
@@ -135,8 +135,8 @@ package object domain {
                                   subject: String,
                                   `object`: String,
                                   knowledge_type: Option[String] = None,
-                                  attribute_constraints: Option[List[TRAPIAttributeConstraint]],
-                                  qualifier_constraints: Option[List[TRAPIQualifierConstraint]])
+                                  attribute_constraints: Option[List[TRAPIAttributeConstraint]] = None,
+                                  qualifier_constraints: Option[List[TRAPIQualifierConstraint]] = None)
 
   final case class TRAPIAttributeConstraint(id: IRI,
                                         name: String,
@@ -153,8 +153,8 @@ package object domain {
   final case class TRAPIEdge(predicate: Option[BiolinkPredicate],
                              subject: IRI,
                              `object`: IRI,
-                             attributes: Option[List[TRAPIAttribute]],
-                             qualifiers: Option[List[TRAPIQualifier]])
+                             attributes: Option[List[TRAPIAttribute]] = None,
+                             qualifiers: Option[List[TRAPIQualifier]] = None)
 
   final case class TRAPIAttribute(attribute_source: Option[String],
                                   attribute_type_id: IRI,
@@ -194,7 +194,7 @@ package object domain {
                                 knowledge_graph: Option[TRAPIKnowledgeGraph],
                                 results: Option[List[TRAPIResult]])
 
-  final case class TRAPIQuery(message: TRAPIMessage, log_level: Option[String], submitter: Option[String])
+  final case class TRAPIQuery(message: TRAPIMessage, log_level: Option[String], submitter: Option[String] = None)
 
   final case class TRAPIResponse(message: TRAPIMessage, status: Option[String], description: Option[String], logs: Option[List[LogEntry]])
 

--- a/src/main/scala/org/renci/cam/domain/package.scala
+++ b/src/main/scala/org/renci/cam/domain/package.scala
@@ -205,7 +205,8 @@ package object domain {
   final case class MetaEdge(subject: BiolinkClass,
                             predicate: BiolinkPredicate,
                             `object`: BiolinkClass,
-                            attributes: Option[List[MetaAttribute]])
+                            attributes: Option[List[MetaAttribute]],
+                            knowledge_types: Option[List[String]] = Some(List("lookup")))
 
   final case class MetaAttribute(attribute_type_id: IRI,
                                  attribute_source: Option[String],

--- a/src/test/scala/org/renci/cam/test/QueryServiceTest.scala
+++ b/src/test/scala/org/renci/cam/test/QueryServiceTest.scala
@@ -386,7 +386,7 @@ object QueryServiceTest extends DefaultRunnableSpec with LazyLogging {
           predicates = Some(List(BiolinkPredicate("related_to", IRI("https://w3id.org/biolink/vocab/related_to")))),
           subject = "n0",
           `object` = "n1",
-          constraints = None
+          attribute_constraints = None
         )
       )
     )


### PR DESCRIPTION
This PR updates the TRAPI model to TRAPI 1.3. This includes:
- Removed the TRAPISubAttribute type and allow attributes to have TRAPIAttributes of their own. See [TRAPI model change](https://github.com/NCATSTranslator/ReasonerAPI/commit/6ec8ea28f3262ac163803622017bb651a4adac33) and [TRAPI ChangeLog](https://github.com/NCATSTranslator/ReasonerAPI/blob/7520ac564e63289dffe092d4c7affd6db4ba22f1/ChangeLog.md).
  - This requires making some usages `lazy` so that they can recursively refer to themselves.
- Updated TRAPINodeBinding to the model described in https://github.com/NCATSTranslator/ReasonerAPI/blob/1e0795a1c4ff5bcac3ccd5f188fdc09ec6bd27c3/TranslatorReasonerAPI.yaml#L468-L505, which includes changes from:
  - https://github.com/NCATSTranslator/ReasonerAPI/pull/304
  - https://github.com/NCATSTranslator/ReasonerAPI/pull/312