### PR TITLE
Improve MetaKnowledgeGraphServiceTest tests

### DIFF
--- a/src/test/scala/org/renci/cam/test/MetaKnowledgeGraphServiceTest.scala
+++ b/src/test/scala/org/renci/cam/test/MetaKnowledgeGraphServiceTest.scala
@@ -3,6 +3,10 @@ package org.renci.cam.test
 import com.typesafe.scalalogging.LazyLogging
 import org.renci.cam.MetaKnowledgeGraphService
 import org.renci.cam.domain.{BiolinkClass, BiolinkPredicate, IRI, MetaEdge, MetaNode}
+import zio.ZIO
+import zio.ZIO.ZIOAutoCloseableOps
+import zio.blocking._
+import zio.stream.ZStream
 import zio.test.Assertion.isNonEmpty
 import zio.test._
 
@@ -12,67 +16,74 @@ object MetaKnowledgeGraphServiceTest extends DefaultRunnableSpec with LazyLoggin
 
   def writeNodesToTSV(tsvFile: File, nodesMap: Map[BiolinkClass, MetaNode]) =
     // Is there an output directory to write to?
-    if (tsvFile.getParentFile.exists()) {
-      // We sort by shorthands
-      val nodesSorted = nodesMap.keySet.map(blc => (blc.shorthand, blc)).toSeq.sortBy(_._1).map(_._2)
+    if (!tsvFile.getParentFile.exists()) ZIO.unit
+    else {
+      effectBlockingIO(new PrintWriter(new FileWriter(tsvFile)))
+        .bracketAuto { pw =>
+          // We sort by shorthands
+          val rows = ZStream
+            .fromIterable(nodesMap.keySet.map(blc => (blc.shorthand, blc)).toSeq.sortBy(_._1).map(_._2))
+            .map { biolinkClass =>
+              val metaNode = nodesMap(biolinkClass)
+              val attrs = metaNode.attributes.getOrElse(List())
 
-      val pw = new PrintWriter(new FileWriter(tsvFile))
+              biolinkClass.shorthand + "\t" +
+                biolinkClass.iri.value + "\t" +
+                metaNode.id_prefixes.mkString("|") + "\t" +
+                attrs.size + "\t" +
+                attrs.mkString("|").replace('\t', ' ')
+            }
 
-      pw.println("biolinkclass\tbiolinkclass_iri\tid_prefixes\tattrs_size\tattrs")
-
-      nodesSorted.foreach { biolinkClass =>
-        val metaNode = nodesMap(biolinkClass)
-        val attrs = metaNode.attributes.getOrElse(List())
-
-        pw.println(
-          biolinkClass.shorthand + "\t" +
-            biolinkClass.iri.value + "\t" +
-            metaNode.id_prefixes.mkString("|") + "\t" +
-            attrs.size + "\t" +
-            attrs.mkString("|").replace('\t', ' ')
-        )
-      }
-
-      pw.close()
+          val output = ZStream("biolinkclass\tbiolinkclass_iri\tid_prefixes\tattrs_size\tattrs") ++ rows
+          output.foreach { row =>
+            pw.println(row)
+            ZIO.unit
+          }
+        }
     }
 
   def writeEdgesToTSV(tsvFile: File, edgesList: List[MetaEdge]) =
-    if (tsvFile.getParentFile.exists()) {
-      val groupedByPreds = edgesList.groupBy(_.predicate)
-      val sortedPreds = groupedByPreds.keySet.toSeq.sortBy(_.shorthand)
+    if (!tsvFile.getParentFile.exists()) ZIO.unit
+    else {
+      effectBlockingIO(new PrintWriter(new FileWriter(tsvFile)))
+        .bracketAuto { pw =>
+          // We sort by predicate
+          val groupedByPreds = edgesList.groupBy(_.predicate)
+          val sortedPreds = groupedByPreds.keySet.toSeq.sortBy(_.shorthand)
 
-      val pw = new PrintWriter(new FileWriter(tsvFile))
+          val rows = ZStream
+            .fromIterable(sortedPreds)
+            .flatMap { predicate =>
+              ZStream.fromIterable(groupedByPreds(predicate)).map { edge =>
+                val attrs = edge.attributes.getOrElse(List())
 
-      pw.println("subject\tsubject_iri\tpredicate\tpredicate_iri\tobject\tobject_iri\tattributes_count\tattributes_list")
+                // I'm going to assume that shorthands and IRIs don't have tabs in them.
+                edge.subject.shorthand + "\t" +
+                  edge.subject.iri.value + "\t" +
+                  edge.predicate.shorthand + "\t" +
+                  edge.predicate.iri.value + "\t" +
+                  edge.`object`.shorthand + "\t" +
+                  edge.`object`.iri.value + "\t" +
+                  attrs.size + "\t" +
+                  attrs.mkString("|").replace('\t', ' ')
+              }
+            }
 
-      sortedPreds.foreach { predicate =>
-        val edges = groupedByPreds(predicate)
+          val output =
+            ZStream("subject\tsubject_iri\tpredicate\tpredicate_iri\tobject\tobject_iri\tattributes_count\tattributes_list") ++ rows
 
-        edges.foreach { edge =>
-          val attrs = edge.attributes.getOrElse(List())
-
-          // I'm going to assume that shorthands and IRIs don't have tabs in them.
-          pw.println(
-            edge.subject.shorthand + "\t" +
-              edge.subject.iri.value + "\t" +
-              edge.predicate.shorthand + "\t" +
-              edge.predicate.iri.value + "\t" +
-              edge.`object`.shorthand + "\t" +
-              edge.`object`.iri.value + "\t" +
-              attrs.size + "\t" +
-              attrs.mkString("|").replace('\t', ' ')
-          )
+          output.foreach { row =>
+            pw.println(row)
+            ZIO.unit
+          }
         }
-      }
-
-      pw.close()
     }
 
   val testGetEdges = suite("MetaKnowledgeGraphService.getEdges")(
     testM("test MetaKnowledgeGraphService.getEdges") {
       for {
         edges <- MetaKnowledgeGraphService.getEdges
-        _ = writeEdgesToTSV(new File("src/test/resources/meta-edges.tsv"), edges)
+        _ <- writeEdgesToTSV(new File("src/test/resources/meta-edges.tsv"), edges)
       } yield {
         val ensureIncludedNamedThingRelatedToNamedThing: TestResult = {
           // In order to meet the requirements of
@@ -107,7 +118,7 @@ object MetaKnowledgeGraphServiceTest extends DefaultRunnableSpec with LazyLoggin
     testM("test MetaKnowledgeGraphService.getNodes") {
       for {
         nodes <- MetaKnowledgeGraphService.getNodes
-        _ = writeNodesToTSV(new File("src/test/resources/meta-nodes.tsv"), nodes)
+        _ <- writeNodesToTSV(new File("src/test/resources/meta-nodes.tsv"), nodes)
       } yield assert(nodes)(isNonEmpty)
     }
   )


### PR DESCRIPTION
This PR improves MetaKnowledgeGraphServiceTest in two ways:
- This test now writes out all reported nodes and edges to TSV files (if there is a `src/test/resources` directory to write to).
- This test also checks to ensure that `biolink:NamedThing biolink:related_to biolink:NamedThing` is in the list of reported edges. Since we shouldn't be asserting this directly, the presence of this MetaEdge should prove that we "includ[e] all implied ancesestor relationships" as required by https://github.com/NCATSTranslator/ReasonerAPI/commit/e2ed87aa4f02dac55dcbd8eac7e190b8c188fbdd