### PR TITLE
Add query_id to NodeBinding

### DIFF
--- a/src/main/scala/org/renci/cam/QueryService.scala
+++ b/src/main/scala/org/renci/cam/QueryService.scala
@@ -6,13 +6,13 @@ import io.circe.syntax._
 import org.apache.jena.query.QuerySolution
 import org.apache.jena.rdf.model.Resource
 import org.phenoscape.sparql.SPARQLInterpolation._
-import org.renci.cam.Biolink.{biolinkData, BiolinkData}
+import org.renci.cam.Biolink.{BiolinkData, biolinkData}
 import org.renci.cam.HttpClient.HttpClient
 import org.renci.cam.SPARQLQueryExecutor.SPARQLCache
 import org.renci.cam.Util.IterableSPARQLOps
 import org.renci.cam.domain.{TRAPIAttribute, _}
-import zio.config.{getConfig, ZConfig}
-import zio.{config => _, Has, RIO, Task, UIO, ZIO}
+import zio.config.{ZConfig, getConfig}
+import zio.{Has, RIO, Task, UIO, ZIO, config => _}
 
 import java.math.BigInteger
 import java.nio.charset.StandardCharsets
@@ -263,6 +263,7 @@ object QueryService extends LazyLogging {
             id = p._2,
             query_id = result.queryGraph.nodes.get(p._1) match {
               // If no nodes IDs were provided, query_id MUST be null or absent.
+              case None                                => None
               case Some(TRAPIQueryNode(None, _, _, _)) => None
               case Some(TRAPIQueryNode(Some(List()), _, _, _)) =>
                 None
@@ -492,7 +493,7 @@ object QueryService extends LazyLogging {
           GROUP BY $typeProjections
           $limitSparql
           """
-    logger.debug(s"Executing query: $queryString")
+    logger.info(s"Executing query: $queryString")
     SPARQLQueryExecutor.runSelectQuery(queryString.toQuery)
   }
 

--- a/src/main/scala/org/renci/cam/QueryService.scala
+++ b/src/main/scala/org/renci/cam/QueryService.scala
@@ -251,7 +251,16 @@ object QueryService extends LazyLogging {
       result <- results
 
       nodeBindings = result.nodes
-        .groupMap(_._1)(p => TRAPINodeBinding(p._2))
+        .groupMap(_._1)(p =>
+          TRAPINodeBinding(
+            id = p._2,
+            query_id = result.originalNodes.get(p._1) match {
+              // According to the TRAPI 1.3 spec, we SHOULD NOT provide a query_id if it is the
+              // same as the id.
+              case Some(p._2) => None
+              case x          => x
+            }
+          ))
         .map(p => (p._1, p._2.toList))
       edgeBindings = result.edges.keys
         .map(key => (key, List(TRAPIEdgeBinding(result.getEdgeKey(key)))))

--- a/src/main/scala/org/renci/cam/QueryService.scala
+++ b/src/main/scala/org/renci/cam/QueryService.scala
@@ -261,11 +261,18 @@ object QueryService extends LazyLogging {
         .groupMap(_._1)(p =>
           TRAPINodeBinding(
             id = p._2,
-            query_id = result.originalNodes.get(p._1) match {
-              // According to the TRAPI 1.3 spec, we SHOULD NOT provide a query_id if it is the
-              // same as the id.
-              case Some(p._2) => None
-              case x          => x
+            query_id = result.queryGraph.nodes.get(p._1) match {
+              // If no nodes IDs were provided, query_id MUST be null or absent.
+              case Some(TRAPIQueryNode(None, _, _, _)) => None
+              case Some(TRAPIQueryNode(Some(List()), _, _, _)) =>
+                None
+              case Some(TRAPIQueryNode(Some(ids), _, _, _)) =>
+                result.originalNodes.get(p._1) match {
+                  // According to the TRAPI 1.3 spec, we SHOULD NOT provide a query_id if it is the
+                  // same as the id.
+                  case Some(p._2) => None
+                  case x          => x
+                }
             }
           ))
         .map(p => (p._1, p._2.toList))

--- a/src/main/scala/org/renci/cam/QueryService.scala
+++ b/src/main/scala/org/renci/cam/QueryService.scala
@@ -6,13 +6,13 @@ import io.circe.syntax._
 import org.apache.jena.query.QuerySolution
 import org.apache.jena.rdf.model.Resource
 import org.phenoscape.sparql.SPARQLInterpolation._
-import org.renci.cam.Biolink.{BiolinkData, biolinkData}
+import org.renci.cam.Biolink.{biolinkData, BiolinkData}
 import org.renci.cam.HttpClient.HttpClient
 import org.renci.cam.SPARQLQueryExecutor.SPARQLCache
 import org.renci.cam.Util.IterableSPARQLOps
 import org.renci.cam.domain.{TRAPIAttribute, _}
-import zio.config.{ZConfig, getConfig}
-import zio.{Has, RIO, Task, UIO, ZIO, config => _}
+import zio.config.{getConfig, ZConfig}
+import zio.{config => _, Has, RIO, Task, UIO, ZIO}
 
 import java.math.BigInteger
 import java.nio.charset.StandardCharsets

--- a/src/test/scala/org/renci/cam/test/QueryServiceTest.scala
+++ b/src/test/scala/org/renci/cam/test/QueryServiceTest.scala
@@ -570,15 +570,12 @@ object QueryServiceTest extends DefaultRunnableSpec with LazyLogging {
 
   def spec = suite("QueryService tests")(
 //    testGetNodeTypes,
-    /*
     testEnforceQueryEdgeTypes,
     testGetTRAPINodeBindings,
     testQueryTexts,
     testGetNodesToDirectTypes,
     testGetProjections,
     testQueryServiceSteps,
-
-     */
     testQueryIds
   ).provideCustomLayer(testLayer.mapError(TestFailure.die))
 

--- a/src/test/scala/org/renci/cam/test/QueryServiceTest.scala
+++ b/src/test/scala/org/renci/cam/test/QueryServiceTest.scala
@@ -454,17 +454,17 @@ object QueryServiceTest extends DefaultRunnableSpec with LazyLogging {
   }
 
   val testQueryIds = {
-    def createTestTRAPIQueryGraph(n0: TRAPIQueryNode, n1: TRAPIQueryNode = TRAPIQueryNode(None, categories=Some(List(BiolinkClass("https://w3id.org/biolink/vocab/GeneOrGeneProduct"))), None),  e0: TRAPIQueryEdge = TRAPIQueryEdge(
+    def createTestTRAPIQueryGraph(n0: TRAPIQueryNode, n1: TRAPIQueryNode = TRAPIQueryNode(None, categories=Some(List(BiolinkClass("GeneOrGeneProduct"))), None),  e0: TRAPIQueryEdge = TRAPIQueryEdge(
       subject="n0",
       `object`="n1",
-      predicates=Some(List(BiolinkPredicate("https://w3id.org/biolink/vocab/affects_activity_of")))
+      predicates=Some(List(BiolinkPredicate("positively_regulates")))
     )) =
       TRAPIQueryGraph(Map("n0" -> n0, "n1" -> n1), Map("e0" -> e0))
 
     suite("testQueryIds")(
       testM("Ensure that query_id is absent for nodes without ids") {
         for {
-          response <- QueryService.run(1000, createTestTRAPIQueryGraph(TRAPIQueryNode(None, Some(List(BiolinkClass("biolink:GeneOrGeneProduct"))), None)))
+          response <- QueryService.run(1000, createTestTRAPIQueryGraph(TRAPIQueryNode(None, Some(List(BiolinkClass("GeneOrGeneProduct"))), None)))
           _ = logger.warn(s"Response: ${response}")
           nodeBindings = response.results.get.flatMap(_.node_bindings.getOrElse("n0", List()))
           queryIds = nodeBindings.map(_.query_id)

--- a/src/test/scala/org/renci/cam/test/QueryServiceTest.scala
+++ b/src/test/scala/org/renci/cam/test/QueryServiceTest.scala
@@ -454,18 +454,22 @@ object QueryServiceTest extends DefaultRunnableSpec with LazyLogging {
   }
 
   val testQueryIds = {
-    def createTestTRAPIQueryGraph(n0: TRAPIQueryNode, n1: TRAPIQueryNode = TRAPIQueryNode(None, categories=Some(List(BiolinkClass("BiologicalProcessOrActivity"))), None),  e0: TRAPIQueryEdge = TRAPIQueryEdge(
-      subject="n0",
-      `object`="n1",
-      predicates=Some(List(BiolinkPredicate("positively_regulates")))
-    )) =
+    def createTestTRAPIQueryGraph(n0: TRAPIQueryNode,
+                                  n1: TRAPIQueryNode =
+                                    TRAPIQueryNode(None, categories = Some(List(BiolinkClass("BiologicalProcessOrActivity"))), None),
+                                  e0: TRAPIQueryEdge = TRAPIQueryEdge(
+                                    subject = "n0",
+                                    `object` = "n1",
+                                    predicates = Some(List(BiolinkPredicate("positively_regulates")))
+                                  )) =
       TRAPIQueryGraph(Map("n0" -> n0, "n1" -> n1), Map("e0" -> e0))
 
     suite("testQueryIds")(
       testM("Ensure that query_id is absent for nodes without ids") {
         for {
-          response <- QueryService.run(1000, createTestTRAPIQueryGraph(TRAPIQueryNode(None, Some(List(BiolinkClass("BiologicalProcessOrActivity"))), None)))
-          _ = logger.warn(s"Response: ${response}")
+          response <- QueryService
+            .run(1000, createTestTRAPIQueryGraph(TRAPIQueryNode(None, Some(List(BiolinkClass("BiologicalProcessOrActivity"))), None)))
+          // _ = logger.warn(s"Response: ${response}")
           nodeBindings = response.message.results.get.flatMap(_.node_bindings.getOrElse("n0", List()))
           queryIds = nodeBindings.map(_.query_id)
         } yield assert(response.message.results)(Assertion.isSome(Assertion.hasSize(Assertion.equalTo(1000)))) &&
@@ -473,8 +477,9 @@ object QueryServiceTest extends DefaultRunnableSpec with LazyLogging {
       },
       testM("Ensure that query_id is present only when the identifier is ambiguous") {
         for {
-          response <- QueryService.run(1000, createTestTRAPIQueryGraph(TRAPIQueryNode(Some(List(IRI("GO:0033549"))), None)))
-          _ = logger.warn(s"Response: ${response}")
+          response <- QueryService
+            .run(1000, createTestTRAPIQueryGraph(TRAPIQueryNode(Some(List(IRI("http://purl.obolibrary.org/obo/GO_0033549"))), None)))
+          // _ = logger.warn(s"Response: ${response}")
           nodeBindings = response.message.results.get.flatMap(_.node_bindings.getOrElse("n0", List()))
           queryIds = nodeBindings.map(_.query_id)
           queryIdsUnambiguous = nodeBindings.filter(_.id == IRI("UniProtKB:Q9HC97")).map(_.query_id)
@@ -490,12 +495,15 @@ object QueryServiceTest extends DefaultRunnableSpec with LazyLogging {
 
   def spec = suite("QueryService tests")(
 //    testGetNodeTypes,
+    /*
     testEnforceQueryEdgeTypes,
     testGetTRAPINodeBindings,
     testQueryTexts,
     testGetNodesToDirectTypes,
     testGetProjections,
     testQueryServiceSteps,
+
+     */
     testQueryIds
   ).provideCustomLayer(testLayer.mapError(TestFailure.die))
 

--- a/src/test/scala/org/renci/cam/test/QueryServiceTest.scala
+++ b/src/test/scala/org/renci/cam/test/QueryServiceTest.scala
@@ -180,7 +180,8 @@ object QueryServiceTest extends DefaultRunnableSpec with LazyLogging {
     zio.test.test("test QueryService.getProjections") {
       val (queryGraph, _) = getSimpleData
       val queryText = QueryService.getProjections(queryGraph)
-      assertTrue(queryText.text.trim.split("\\s+", -1).to(Set) == Set("?e0", "?n1", "?n0"))
+      // In addition to ?e0, ?n0, ?n1, we also return ?n0_class and ?n1_class in order to be able to identify the original class.
+      assertTrue(queryText.text.trim.split("\\s+", -1).to(Set) == Set("?e0", "?n0", "?n1", "?n0_class", "?n1_class"))
     }
   )
 

--- a/src/test/scala/org/renci/cam/test/QueryServiceTest.scala
+++ b/src/test/scala/org/renci/cam/test/QueryServiceTest.scala
@@ -454,7 +454,7 @@ object QueryServiceTest extends DefaultRunnableSpec with LazyLogging {
   }
 
   val testQueryIds = {
-    def createTestTRAPIQueryGraph(n0: TRAPIQueryNode, n1: TRAPIQueryNode = TRAPIQueryNode(None, categories=Some(List(BiolinkClass("GeneOrGeneProduct"))), None),  e0: TRAPIQueryEdge = TRAPIQueryEdge(
+    def createTestTRAPIQueryGraph(n0: TRAPIQueryNode, n1: TRAPIQueryNode = TRAPIQueryNode(None, categories=Some(List(BiolinkClass("BiologicalProcessOrActivity"))), None),  e0: TRAPIQueryEdge = TRAPIQueryEdge(
       subject="n0",
       `object`="n1",
       predicates=Some(List(BiolinkPredicate("positively_regulates")))
@@ -464,22 +464,22 @@ object QueryServiceTest extends DefaultRunnableSpec with LazyLogging {
     suite("testQueryIds")(
       testM("Ensure that query_id is absent for nodes without ids") {
         for {
-          response <- QueryService.run(1000, createTestTRAPIQueryGraph(TRAPIQueryNode(None, Some(List(BiolinkClass("GeneOrGeneProduct"))), None)))
+          response <- QueryService.run(1000, createTestTRAPIQueryGraph(TRAPIQueryNode(None, Some(List(BiolinkClass("BiologicalProcessOrActivity"))), None)))
           _ = logger.warn(s"Response: ${response}")
-          nodeBindings = response.results.get.flatMap(_.node_bindings.getOrElse("n0", List()))
+          nodeBindings = response.message.results.get.flatMap(_.node_bindings.getOrElse("n0", List()))
           queryIds = nodeBindings.map(_.query_id)
-        } yield assert(response.results)(Assertion.isSome(Assertion.hasSize(Assertion.equalTo(1000)))) &&
+        } yield assert(response.message.results)(Assertion.isSome(Assertion.hasSize(Assertion.equalTo(1000)))) &&
           assert(queryIds)(Assertion.forall(Assertion.isNone))
       },
       testM("Ensure that query_id is present only when the identifier is ambiguous") {
         for {
-          response <- QueryService.run(1000, createTestTRAPIQueryGraph(TRAPIQueryNode(Some(List(IRI("UniProtKB:Q9HC97"))), None)))
+          response <- QueryService.run(1000, createTestTRAPIQueryGraph(TRAPIQueryNode(Some(List(IRI("GO:0033549"))), None)))
           _ = logger.warn(s"Response: ${response}")
-          nodeBindings = response.results.get.flatMap(_.node_bindings.getOrElse("n0", List()))
+          nodeBindings = response.message.results.get.flatMap(_.node_bindings.getOrElse("n0", List()))
           queryIds = nodeBindings.map(_.query_id)
           queryIdsUnambiguous = nodeBindings.filter(_.id == IRI("UniProtKB:Q9HC97")).map(_.query_id)
           queryIdsAmbiguous = nodeBindings.filter(_.id == IRI("UniProtKB:Q9HC97")).map(_.query_id)
-        } yield assert(response.results)(Assertion.isSome(Assertion.hasSize(Assertion.equalTo(1000)))) &&
+        } yield assert(response.message.results)(Assertion.isSome(Assertion.hasSize(Assertion.equalTo(1000)))) &&
           assert(queryIds)(Assertion.forall(Assertion.isNone))
       }
     )

--- a/src/test/scala/org/renci/cam/test/QueryServiceTest.scala
+++ b/src/test/scala/org/renci/cam/test/QueryServiceTest.scala
@@ -453,6 +453,21 @@ object QueryServiceTest extends DefaultRunnableSpec with LazyLogging {
     )
   }
 
+  val testQueryIds = suite("testQueryIds") {
+    def createTestTRAPIQueryGraph(n0: TRAPIQueryNode, n1: TRAPIQueryNode = TRAPIQueryNode(None, categories=Some(List(BiolinkClass("https://w3id.org/biolink/vocab/GeneOrGeneProduct"))), None),  e0: TRAPIQueryEdge = TRAPIQueryEdge(
+      subject="n0",
+      `object`="n1",
+      predicates=Some(List(BiolinkPredicate("https://w3id.org/biolink/vocab/in_pathway_with")))
+    )) =
+      TRAPIQueryGraph(Map("n0" -> n0, "n1" -> n1), Map("e0" -> e0))
+
+    testM("Ensure that query_id is absent for nodes without ids") {
+      for {
+        response <- QueryService.run(1000, createTestTRAPIQueryGraph(TRAPIQueryNode(None, Some(List(BiolinkClass("biolink:GeneOrGeneProduct"))), None)))
+      } yield assert(response.results)(Assertion.isSome(Assertion.hasSize(Assertion.equalTo(1000))))
+    }
+  }
+
   val configLayer: Layer[Throwable, ZConfig[AppConfig]] = TypesafeConfig.fromDefaultLoader(AppConfig.config)
   val testLayer = HttpClient.makeHttpClientLayer ++ Biolink.makeUtilitiesLayer ++ configLayer >+> SPARQLQueryExecutor.makeCache.toLayer
 

--- a/src/test/scala/org/renci/cam/test/QueryServiceTest.scala
+++ b/src/test/scala/org/renci/cam/test/QueryServiceTest.scala
@@ -527,7 +527,7 @@ object QueryServiceTest extends DefaultRunnableSpec with LazyLogging {
           assert(node0Bindings)(Assertion.contains(TRAPINodeBinding(id = germplasm, query_id = Some(cytoplasm))))
       },
       testM("Ensure that two different identifiers can be provided for the same node, to be disambiguated by query_id") {
-        val dna = IRI("http://purl.obolibrary.org/obo/CHEBI_16991")
+        val glucose = IRI("http://purl.obolibrary.org/obo/CHEBI_17234")
         val rna = IRI("http://purl.obolibrary.org/obo/CHEBI_33697")
 
         for {
@@ -535,7 +535,7 @@ object QueryServiceTest extends DefaultRunnableSpec with LazyLogging {
             .run(
               1000,
               createTestTRAPIQueryGraph(
-                TRAPIQueryNode(Some(List(dna, rna)), None),
+                TRAPIQueryNode(Some(List(glucose, rna)), None),
                 TRAPIQueryNode(None, categories = Some(List(BiolinkClass("BiologicalProcessOrActivity"))), None),
                 TRAPIQueryEdge(
                   subject = "n1",
@@ -546,21 +546,21 @@ object QueryServiceTest extends DefaultRunnableSpec with LazyLogging {
             )
           // _ = logger.warn(s"Response: ${response}")
           node0Bindings = response.message.results.get.flatMap(_.node_bindings.getOrElse("n0", List()))
-          queryIdsUnambiguous = node0Bindings.filter(b => b.id == dna || b.id == rna).map(_.query_id)
-          idsAmbiguousDNA = node0Bindings.filter(_.query_id.contains(dna)).map(_.id)
+          queryIdsUnambiguous = node0Bindings.filter(b => b.id == glucose || b.id == rna).map(_.query_id)
+          idsAmbiguousGlucose = node0Bindings.filter(_.query_id.contains(glucose)).map(_.id)
           idsAmbiguousRNA = node0Bindings.filter(_.query_id.contains(rna)).map(_.id)
         } yield assert(response.message.results)(Assertion.isSome(Assertion.hasSize(Assertion.isGreaterThanEqualTo(50)))) &&
-          // All unambiguous IDs -- DNA and RNA -- should have empty query_ids.
+          // All unambiguous IDs -- glucose and RNA -- should have empty query_ids.
           assert(queryIdsUnambiguous)(Assertion.isNonEmpty) &&
           assert(queryIdsUnambiguous)(Assertion.forall(Assertion.isNone)) &&
-          // Ambiguous IDs that came from DNA should not have either DNA or RNA in them.
-          assert(idsAmbiguousDNA)(Assertion.isNonEmpty) &&
-          assert(idsAmbiguousDNA)(Assertion.not(Assertion.contains(TRAPINodeBinding(id = rna, query_id = Some(rna))))) &&
-          assert(idsAmbiguousDNA)(Assertion.not(Assertion.contains(TRAPINodeBinding(id = rna, query_id = Some(dna))))) &&
+          // Ambiguous IDs that came from glucose should not have either glucose or RNA in them.
+          assert(idsAmbiguousGlucose)(Assertion.isNonEmpty) &&
+          assert(idsAmbiguousGlucose)(Assertion.not(Assertion.contains(TRAPINodeBinding(id = glucose, query_id = Some(glucose))))) &&
+          assert(idsAmbiguousGlucose)(Assertion.not(Assertion.contains(TRAPINodeBinding(id = rna, query_id = Some(glucose))))) &&
           // Ambiguous IDs that came from RNA should not have either DNA or RNA in them.
           assert(idsAmbiguousRNA)(Assertion.isNonEmpty) &&
-          assert(idsAmbiguousRNA)(Assertion.not(Assertion.contains(TRAPINodeBinding(id = dna, query_id = Some(rna))))) &&
-          assert(idsAmbiguousDNA)(Assertion.not(Assertion.contains(TRAPINodeBinding(id = rna, query_id = Some(rna)))))
+          assert(idsAmbiguousRNA)(Assertion.not(Assertion.contains(TRAPINodeBinding(id = glucose, query_id = Some(rna))))) &&
+          assert(idsAmbiguousRNA)(Assertion.not(Assertion.contains(TRAPINodeBinding(id = rna, query_id = Some(rna)))))
       }
     )
   }


### PR DESCRIPTION
CAM-KP-API currently will return more specific identifiers of the specified identifier in results (for example, if asked to search for [cytoplasm](https://www.ebi.ac.uk/QuickGO/term/GO:0005737), we will return [germ plasm](https://www.ebi.ac.uk/QuickGO/term/GO:0060293) as well). As per the TRAPI 1.3 `query_id` documentation at https://github.com/NCATSTranslator/ReasonerAPI/blob/1e0795a1c4ff5bcac3ccd5f188fdc09ec6bd27c3/TranslatorReasonerAPI.yaml#L481-L492, "If the bound QNode has one or more CURIEs as an 'id' and this NodeBinding's 'id' refers to a QNode 'id' in a manner where the CURIEs are different (typically due to the NodeBinding.id being a descendant of a QNode.id), then this query_id MUST be provided." This PR implements that.