### PR TITLE
Check for unsupported constraints

### DIFF
--- a/src/main/scala/org/renci/cam/Server.scala
+++ b/src/main/scala/org/renci/cam/Server.scala
@@ -134,8 +134,8 @@ object Server extends App with LazyLogging {
               .fromOption(body.message.query_graph)
               .orElseFail(new InvalidBodyException("A query graph is required, but hasn't been provided."))
           limitValue <- ZIO.fromOption(limit).orElse(ZIO.effect(1000))
-          message <- QueryService.run(limitValue, queryGraph)
-        } yield TRAPIResponse(message, Some("Success"), None, None)
+          response <- QueryService.run(limitValue, queryGraph)
+        } yield response
         program.mapError(error => error.getMessage)
       }
       .toRoutes

--- a/src/test/scala/org/renci/cam/test/LimitTest.scala
+++ b/src/test/scala/org/renci/cam/test/LimitTest.scala
@@ -44,7 +44,8 @@ object LimitTest extends DefaultRunnableSpec with LazyLogging {
         .map(limit =>
           testM(s"Test query with limit of $limit expecting $queryGraphExpectedResults results") {
             for {
-              message <- QueryService.run(limit, testQueryGraph)
+              response <- QueryService.run(limit, testQueryGraph)
+              message = response.message
               _ = logger.info(s"Retrieved ${message.results.get.size} results when limit=$limit")
               results = message.results.get
             } yield {

--- a/src/test/scala/org/renci/cam/test/TRAPITest.scala
+++ b/src/test/scala/org/renci/cam/test/TRAPITest.scala
@@ -1,0 +1,92 @@
+package org.renci.cam.test
+
+import com.typesafe.scalalogging.LazyLogging
+import io.circe._
+import io.circe.generic.auto._
+import io.circe.generic.semiauto._
+import org.http4s.headers.{`Content-Type`, Accept}
+import org.http4s.{EntityDecoder, MediaType, Method, Request, Uri}
+import org.renci.cam.Biolink.biolinkData
+import org.renci.cam._
+import org.renci.cam.domain.{BiolinkClass, BiolinkPredicate, IRI, TRAPIAttribute, TRAPIResponse}
+import zio.config.ZConfig
+import zio.config.typesafe.TypesafeConfig
+import zio.interop.catz.concurrentInstance
+import zio.test._
+import zio.{Layer, ZIO}
+
+object TRAPITest extends DefaultRunnableSpec with LazyLogging {
+
+  /** This query contains two unexpected properties:
+    *   - unknown_qnode_property on the "n0" QNode
+    *   - unknown_qedge_property on the "e0" QEdge As per https://github.com/NCATSTranslator/ReasonerAPI/pull/322, a server receiving an
+    *     unknown property SHOULD generate a warning and MAY continue processing.
+    */
+  val testUnexpectedPropertiesOnQNodeAndQEdge = suite("testUnexpectedPropertiesOnQNodeAndQEdge") {
+    //
+    val query = """{
+                     "message": {
+                       "query_graph": {
+                         "nodes": {
+                           "n0": {
+                             "categories": ["biolink:GeneOrGeneProduct"],
+                             "unknown_qnode_property": "A1"
+                           },
+                           "n1": { "categories": ["biolink:AnatomicalEntity"], "ids": ["GO:0005634"] }
+                         },
+                         "edges": {
+                           "e0": {
+                             "subject": "n0",
+                             "object": "n1",
+                             "predicates": ["biolink:part_of"],
+                             "unknown_qedge_property": "B2"
+                           }
+                         }
+                       }
+                     }
+                   }"""
+
+    testM("test unexpected properties on QNode and QEdge") {
+      for {
+        biolinkData <- biolinkData
+
+        server <- Server.httpApp
+        response <- server(
+          Request(
+            method = Method.POST,
+            uri = Uri.unsafeFromString("/query")
+          )
+            .withHeaders(Accept(MediaType.application.json), `Content-Type`(MediaType.application.json))
+            .withEntity(query)
+        )
+        content <- EntityDecoder.decodeText(response)
+        trapiResponseJson <- ZIO.fromEither(io.circe.parser.parse(content))
+
+        trapiResponse <- ZIO.fromEither(
+          {
+            implicit val decoderIRI: Decoder[IRI] = Implicits.iriDecoder(biolinkData.prefixes)
+            implicit val keyDecoderIRI: KeyDecoder[IRI] = Implicits.iriKeyDecoder(biolinkData.prefixes)
+            implicit val decoderBiolinkClass: Decoder[BiolinkClass] = Implicits.biolinkClassDecoder(biolinkData.classes)
+            implicit val decoderBiolinkPredicate: Decoder[BiolinkPredicate] =
+              Implicits.biolinkPredicateDecoder(biolinkData.predicates)
+            implicit lazy val decoderTRAPIAttribute: Decoder[TRAPIAttribute] = deriveDecoder[TRAPIAttribute]
+
+            trapiResponseJson.as[TRAPIResponse]
+          }
+        )
+
+        logs = trapiResponse.logs
+      } yield assert(response.status)(Assertion.hasField("isSuccess", _.isSuccess, Assertion.isTrue)) &&
+        assert(content)(Assertion.isNonEmptyString) &&
+        assert(logs)(Assertion.isSome(Assertion.isNonEmpty))
+    }
+  }
+
+  val configLayer: Layer[Throwable, ZConfig[AppConfig]] = TypesafeConfig.fromDefaultLoader(AppConfig.config)
+  val testLayer = HttpClient.makeHttpClientLayer ++ Biolink.makeUtilitiesLayer ++ configLayer >+> SPARQLQueryExecutor.makeCache.toLayer
+
+  def spec = suite("OpenAPI tests")(
+    testUnexpectedPropertiesOnQNodeAndQEdge
+  ).provideCustomLayer(testLayer.mapError(TestFailure.die))
+
+}

--- a/src/test/scala/org/renci/cam/test/TRAPITest.scala
+++ b/src/test/scala/org/renci/cam/test/TRAPITest.scala
@@ -85,7 +85,7 @@ object TRAPITest extends DefaultRunnableSpec with LazyLogging {
   val configLayer: Layer[Throwable, ZConfig[AppConfig]] = TypesafeConfig.fromDefaultLoader(AppConfig.config)
   val testLayer = HttpClient.makeHttpClientLayer ++ Biolink.makeUtilitiesLayer ++ configLayer >+> SPARQLQueryExecutor.makeCache.toLayer
 
-  def spec = suite("OpenAPI tests")(
+  def spec = suite("TRAPI tests")(
     testUnexpectedPropertiesOnQNodeAndQEdge
   ).provideCustomLayer(testLayer.mapError(TestFailure.die))
 

--- a/src/test/scala/org/renci/cam/test/TRAPITest.scala
+++ b/src/test/scala/org/renci/cam/test/TRAPITest.scala
@@ -4,25 +4,30 @@ import com.typesafe.scalalogging.LazyLogging
 import io.circe._
 import io.circe.generic.auto._
 import io.circe.generic.semiauto._
+import org.apache.jena.query.{Query, QuerySolution}
 import org.http4s.headers.{`Content-Type`, Accept}
 import org.http4s.{EntityDecoder, MediaType, Method, Request, Uri}
 import org.renci.cam.Biolink.biolinkData
+import org.renci.cam.HttpClient.HttpClient
+import org.renci.cam.Server.EndpointEnv
 import org.renci.cam._
 import org.renci.cam.domain.{BiolinkClass, BiolinkPredicate, IRI, LogEntry, TRAPIAttribute, TRAPIResponse}
+import zio.cache.Cache
 import zio.config.ZConfig
 import zio.config.typesafe.TypesafeConfig
 import zio.interop.catz.concurrentInstance
 import zio.test._
-import zio.{Layer, ZIO}
+import zio.{Layer, ZIO, ZLayer}
 
 object TRAPITest extends DefaultRunnableSpec with LazyLogging {
 
   /** If CAM-KP-API receives a attribute constraint that it does not support, it MUST respond with an error Code
     * "UnsupportedAttributeConstraint".
     */
-  val testUnsupportedAttributeConstraints = suite("testUnsupportedAttributeConstraints") {
-    // Examples taken from https://github.com/NCATSTranslator/ReasonerAPI/blob/1e0795a1c4ff5bcac3ccd5f188fdc09ec6bd27c3/ImplementationRules.md#specifying-permitted-and-excluded-kps-to-an-ara
-    val query = """{
+  val testUnsupportedAttributeConstraints: Spec[EndpointEnv, TestFailure[Throwable], TestSuccess] =
+    suite("testUnsupportedAttributeConstraints") {
+      // Examples taken from https://github.com/NCATSTranslator/ReasonerAPI/blob/1e0795a1c4ff5bcac3ccd5f188fdc09ec6bd27c3/ImplementationRules.md#specifying-permitted-and-excluded-kps-to-an-ara
+      val query = """{
                      "message": {
                        "query_graph": {
                          "nodes": {
@@ -49,49 +54,49 @@ object TRAPITest extends DefaultRunnableSpec with LazyLogging {
                      }
                    }"""
 
-    testM("test unsupported attribute constraint") {
-      for {
-        biolinkData <- biolinkData
+      testM("test unsupported attribute constraint") {
+        for {
+          biolinkData <- biolinkData
 
-        server <- Server.httpApp
-        response <- server(
-          Request(
-            method = Method.POST,
-            uri = Uri.unsafeFromString("/query")
+          server <- Server.httpApp
+          response <- server(
+            Request(
+              method = Method.POST,
+              uri = Uri.unsafeFromString("/query")
+            )
+              .withHeaders(Accept(MediaType.application.json), `Content-Type`(MediaType.application.json))
+              .withEntity(query)
           )
-            .withHeaders(Accept(MediaType.application.json), `Content-Type`(MediaType.application.json))
-            .withEntity(query)
-        )
-        content <- EntityDecoder.decodeText(response)
-        trapiResponseJson <- ZIO.fromEither(io.circe.parser.parse(content))
+          content <- EntityDecoder.decodeText(response)
+          trapiResponseJson <- ZIO.fromEither(io.circe.parser.parse(content))
 
-        trapiResponse <- ZIO.fromEither(
-          {
-            implicit val decoderIRI: Decoder[IRI] = Implicits.iriDecoder(biolinkData.prefixes)
-            implicit val keyDecoderIRI: KeyDecoder[IRI] = Implicits.iriKeyDecoder(biolinkData.prefixes)
-            implicit val decoderBiolinkClass: Decoder[BiolinkClass] = Implicits.biolinkClassDecoder(biolinkData.classes)
-            implicit val decoderBiolinkPredicate: Decoder[BiolinkPredicate] =
-              Implicits.biolinkPredicateDecoder(biolinkData.predicates)
-            implicit lazy val decoderTRAPIAttribute: Decoder[TRAPIAttribute] = deriveDecoder[TRAPIAttribute]
+          trapiResponse <- ZIO.fromEither(
+            {
+              implicit val decoderIRI: Decoder[IRI] = Implicits.iriDecoder(biolinkData.prefixes)
+              implicit val keyDecoderIRI: KeyDecoder[IRI] = Implicits.iriKeyDecoder(biolinkData.prefixes)
+              implicit val decoderBiolinkClass: Decoder[BiolinkClass] = Implicits.biolinkClassDecoder(biolinkData.classes)
+              implicit val decoderBiolinkPredicate: Decoder[BiolinkPredicate] =
+                Implicits.biolinkPredicateDecoder(biolinkData.predicates)
+              implicit lazy val decoderTRAPIAttribute: Decoder[TRAPIAttribute] = deriveDecoder[TRAPIAttribute]
 
-            trapiResponseJson.as[TRAPIResponse]
+              trapiResponseJson.as[TRAPIResponse]
+            }
+          )
+
+          logs = trapiResponse.logs
+          logsWithUnsupportedAttributeConstraint = logs.getOrElse(List()).filter {
+            case LogEntry(_, Some("Error"), Some("UnsupportedAttributeConstraint"), _) => true
+            case _                                                                     => false
           }
-        )
-
-        logs = trapiResponse.logs
-        logsWithUnsupportedAttributeConstraint = logs.getOrElse(List()).filter {
-          case LogEntry(_, Some("Error"), Some("UnsupportedAttributeConstraint"), _) => true
-          case _                                                                     => false
-        }
-      } yield assert(response.status)(Assertion.hasField("isSuccess", _.isSuccess, Assertion.isTrue)) &&
-        assert(content)(Assertion.isNonEmptyString) &&
-        // Should return an UnsupportedAttributeConstraint as the status ...
-        assert(trapiResponse.status)(Assertion.isSome(Assertion.equalTo("UnsupportedAttributeConstraint"))) &&
-        // ... and in the logs.
-        assert(logs)(Assertion.isSome(Assertion.isNonEmpty)) &&
-        assert(logsWithUnsupportedAttributeConstraint)(Assertion.isNonEmpty)
+        } yield assert(response.status)(Assertion.hasField("isSuccess", _.isSuccess, Assertion.isTrue)) &&
+          assert(content)(Assertion.isNonEmptyString) &&
+          // Should return an UnsupportedAttributeConstraint as the status ...
+          assert(trapiResponse.status)(Assertion.isSome(Assertion.equalTo("UnsupportedAttributeConstraint"))) &&
+          // ... and in the logs.
+          assert(logs)(Assertion.isSome(Assertion.isNonEmpty)) &&
+          assert(logsWithUnsupportedAttributeConstraint)(Assertion.isNonEmpty)
+      }
     }
-  }
 
   /** If CAM-KP-API receives a qualifier constraint that it does not support, it MUST return an empty response (since no edges meet the
     * constraint).
@@ -177,9 +182,14 @@ object TRAPITest extends DefaultRunnableSpec with LazyLogging {
   }
 
   val configLayer: Layer[Throwable, ZConfig[AppConfig]] = TypesafeConfig.fromDefaultLoader(AppConfig.config)
-  val testLayer = HttpClient.makeHttpClientLayer ++ Biolink.makeUtilitiesLayer ++ configLayer >+> SPARQLQueryExecutor.makeCache.toLayer
 
-  def spec = suite("TRAPI tests")(
+  val testLayer: ZLayer[
+    Any,
+    Throwable,
+    HttpClient with ZConfig[Biolink.BiolinkData] with ZConfig[AppConfig] with ZConfig[Cache[Query, Throwable, List[QuerySolution]]]] =
+    HttpClient.makeHttpClientLayer ++ Biolink.makeUtilitiesLayer ++ configLayer >+> SPARQLQueryExecutor.makeCache.toLayer
+
+  def spec: Spec[environment.TestEnvironment, TestFailure[Throwable], TestSuccess] = suite("TRAPI tests")(
     testUnsupportedAttributeConstraints,
     testUnsupportedQualifierConstraints
   ).provideCustomLayer(testLayer.mapError(TestFailure.die))

--- a/src/test/scala/org/renci/cam/test/TRAPITest.scala
+++ b/src/test/scala/org/renci/cam/test/TRAPITest.scala
@@ -85,7 +85,7 @@ object TRAPITest extends DefaultRunnableSpec with LazyLogging {
 
           logs = trapiResponse.logs
           logsWithUnsupportedAttributeConstraint = logs.getOrElse(List()).filter {
-            case LogEntry(_, Some("Error"), Some("UnsupportedAttributeConstraint"), _) => true
+            case LogEntry(_, Some("ERROR"), Some("UnsupportedAttributeConstraint"), _) => true
             case _                                                                     => false
           }
         } yield assert(response.status)(Assertion.hasField("isSuccess", _.isSuccess, Assertion.isTrue)) &&

--- a/src/test/scala/org/renci/cam/test/TRAPITest.scala
+++ b/src/test/scala/org/renci/cam/test/TRAPITest.scala
@@ -4,7 +4,7 @@ import com.typesafe.scalalogging.LazyLogging
 import io.circe._
 import io.circe.generic.auto._
 import io.circe.generic.semiauto._
-import org.http4s.headers.{Accept, `Content-Type`}
+import org.http4s.headers.{`Content-Type`, Accept}
 import org.http4s.{EntityDecoder, MediaType, Method, Request, Uri}
 import org.renci.cam.Biolink.biolinkData
 import org.renci.cam._
@@ -17,10 +17,9 @@ import zio.{Layer, ZIO}
 
 object TRAPITest extends DefaultRunnableSpec with LazyLogging {
 
-  /**
-   * If CAM-KP-API receives a attribute constraint that it does not support, it MUST respond with an error Code
-   * "UnsupportedAttributeConstraint".
-   */
+  /** If CAM-KP-API receives a attribute constraint that it does not support, it MUST respond with an error Code
+    * "UnsupportedAttributeConstraint".
+    */
   val testUnsupportedAttributeConstraints = suite("testUnsupportedAttributeConstraints") {
     // Examples taken from https://github.com/NCATSTranslator/ReasonerAPI/blob/1e0795a1c4ff5bcac3ccd5f188fdc09ec6bd27c3/ImplementationRules.md#specifying-permitted-and-excluded-kps-to-an-ara
     val query = """{
@@ -80,10 +79,10 @@ object TRAPITest extends DefaultRunnableSpec with LazyLogging {
         )
 
         logs = trapiResponse.logs
-        logsWithUnsupportedAttributeConstraint = logs.getOrElse(List()).filter({
+        logsWithUnsupportedAttributeConstraint = logs.getOrElse(List()).filter {
           case LogEntry(_, Some("Error"), Some("UnsupportedAttributeConstraint"), _) => true
-          case _ => false
-        })
+          case _                                                                     => false
+        }
       } yield assert(response.status)(Assertion.hasField("isSuccess", _.isSuccess, Assertion.isTrue)) &&
         assert(content)(Assertion.isNonEmptyString) &&
         // Should return an UnsupportedAttributeConstraint as the status ...
@@ -94,12 +93,11 @@ object TRAPITest extends DefaultRunnableSpec with LazyLogging {
     }
   }
 
-  /**
-   * If CAM-KP-API receives a qualifier constraint that it does not support, it MUST return an empty response (since no
-   * edges meet the constraint).
-   *
-   * (This is still in development at https://github.com/NCATSTranslator/ReasonerAPI/pull/364)
-   */
+  /** If CAM-KP-API receives a qualifier constraint that it does not support, it MUST return an empty response (since no edges meet the
+    * constraint).
+    *
+    * (This is still in development at https://github.com/NCATSTranslator/ReasonerAPI/pull/364)
+    */
   val testUnsupportedQualifierConstraints = suite("testUnsupportedConstraints") {
     // Examples taken from https://github.com/NCATSTranslator/ReasonerAPI/blob/7520ac564e63289dffe092d4c7affd6db4ba22f1/examples/Message/subject_and_object_qualifiers.json
     val query = """{
@@ -131,7 +129,6 @@ object TRAPITest extends DefaultRunnableSpec with LazyLogging {
                      }
                    }"""
 
-
     testM("test unsupported qualifier constraint on QEdge") {
       for {
         biolinkData <- biolinkData
@@ -162,11 +159,11 @@ object TRAPITest extends DefaultRunnableSpec with LazyLogging {
         )
 
         logs = trapiResponse.logs
-        logWarningOfQualifierConstraints = logs.getOrElse(List()).filter({
+        logWarningOfQualifierConstraints = logs.getOrElse(List()).filter {
           // We've made this up ourselves.
           case LogEntry(_, Some("Warning"), Some("UnsupportedQualifierConstraint"), _) => true
-          case _ => false
-        })
+          case _                                                                       => false
+        }
       } yield assert(response.status)(Assertion.hasField("isSuccess", _.isSuccess, Assertion.isTrue)) &&
         assert(content)(Assertion.isNonEmptyString) &&
         // Should return an overall status of Success
@@ -179,76 +176,10 @@ object TRAPITest extends DefaultRunnableSpec with LazyLogging {
     }
   }
 
-  /** This query contains two unexpected properties:
-    *   - unknown_qnode_property on the "n0" QNode
-    *   - unknown_qedge_property on the "e0" QEdge As per https://github.com/NCATSTranslator/ReasonerAPI/pull/322, a server receiving an
-    *     unknown property SHOULD generate a warning and MAY continue processing.
-    */
-  val testUnexpectedPropertiesOnQNodeAndQEdge = suite("testUnexpectedPropertiesOnQNodeAndQEdge") {
-    //
-    val query = """{
-                     "message": {
-                       "query_graph": {
-                         "nodes": {
-                           "n0": {
-                             "categories": ["biolink:GeneOrGeneProduct"],
-                             "unknown_qnode_property": "A1"
-                           },
-                           "n1": { "categories": ["biolink:AnatomicalEntity"], "ids": ["GO:0005634"] }
-                         },
-                         "edges": {
-                           "e0": {
-                             "subject": "n0",
-                             "object": "n1",
-                             "predicates": ["biolink:part_of"],
-                             "unknown_qedge_property": "B2"
-                           }
-                         }
-                       }
-                     }
-                   }"""
-
-    testM("test unexpected properties on QNode and QEdge") {
-      for {
-        biolinkData <- biolinkData
-
-        server <- Server.httpApp
-        response <- server(
-          Request(
-            method = Method.POST,
-            uri = Uri.unsafeFromString("/query")
-          )
-            .withHeaders(Accept(MediaType.application.json), `Content-Type`(MediaType.application.json))
-            .withEntity(query)
-        )
-        content <- EntityDecoder.decodeText(response)
-        trapiResponseJson <- ZIO.fromEither(io.circe.parser.parse(content))
-
-        trapiResponse <- ZIO.fromEither(
-          {
-            implicit val decoderIRI: Decoder[IRI] = Implicits.iriDecoder(biolinkData.prefixes)
-            implicit val keyDecoderIRI: KeyDecoder[IRI] = Implicits.iriKeyDecoder(biolinkData.prefixes)
-            implicit val decoderBiolinkClass: Decoder[BiolinkClass] = Implicits.biolinkClassDecoder(biolinkData.classes)
-            implicit val decoderBiolinkPredicate: Decoder[BiolinkPredicate] =
-              Implicits.biolinkPredicateDecoder(biolinkData.predicates)
-            implicit lazy val decoderTRAPIAttribute: Decoder[TRAPIAttribute] = deriveDecoder[TRAPIAttribute]
-
-            trapiResponseJson.as[TRAPIResponse]
-          }
-        )
-
-        logs = trapiResponse.logs
-      } yield assert(response.status)(Assertion.hasField("isSuccess", _.isSuccess, Assertion.isTrue)) &&
-        assert(content)(Assertion.isNonEmptyString) &&
-        assert(logs)(Assertion.isSome(Assertion.isNonEmpty))
-    }
-  }
-
   val configLayer: Layer[Throwable, ZConfig[AppConfig]] = TypesafeConfig.fromDefaultLoader(AppConfig.config)
   val testLayer = HttpClient.makeHttpClientLayer ++ Biolink.makeUtilitiesLayer ++ configLayer >+> SPARQLQueryExecutor.makeCache.toLayer
 
   def spec = suite("TRAPI tests")(
-    testUnexpectedPropertiesOnQNodeAndQEdge,
     testUnsupportedAttributeConstraints,
     testUnsupportedQualifierConstraints
   ).provideCustomLayer(testLayer.mapError(TestFailure.die))

--- a/src/test/scala/org/renci/cam/test/TRAPITest.scala
+++ b/src/test/scala/org/renci/cam/test/TRAPITest.scala
@@ -166,7 +166,7 @@ object TRAPITest extends DefaultRunnableSpec with LazyLogging {
         logs = trapiResponse.logs
         logWarningOfQualifierConstraints = logs.getOrElse(List()).filter {
           // We've made this up ourselves.
-          case LogEntry(_, Some("Warning"), Some("UnsupportedQualifierConstraint"), _) => true
+          case LogEntry(_, Some("WARNING"), Some("UnsupportedQualifierConstraint"), _) => true
           case _                                                                       => false
         }
       } yield assert(response.status)(Assertion.hasField("isSuccess", _.isSuccess, Assertion.isTrue)) &&

--- a/src/test/scala/org/renci/cam/test/TRAPITest.scala
+++ b/src/test/scala/org/renci/cam/test/TRAPITest.scala
@@ -4,11 +4,11 @@ import com.typesafe.scalalogging.LazyLogging
 import io.circe._
 import io.circe.generic.auto._
 import io.circe.generic.semiauto._
-import org.http4s.headers.{`Content-Type`, Accept}
+import org.http4s.headers.{Accept, `Content-Type`}
 import org.http4s.{EntityDecoder, MediaType, Method, Request, Uri}
 import org.renci.cam.Biolink.biolinkData
 import org.renci.cam._
-import org.renci.cam.domain.{BiolinkClass, BiolinkPredicate, IRI, TRAPIAttribute, TRAPIResponse}
+import org.renci.cam.domain.{BiolinkClass, BiolinkPredicate, IRI, LogEntry, TRAPIAttribute, TRAPIResponse}
 import zio.config.ZConfig
 import zio.config.typesafe.TypesafeConfig
 import zio.interop.catz.concurrentInstance
@@ -16,6 +16,168 @@ import zio.test._
 import zio.{Layer, ZIO}
 
 object TRAPITest extends DefaultRunnableSpec with LazyLogging {
+
+  /**
+   * If CAM-KP-API receives a attribute constraint that it does not support, it MUST respond with an error Code
+   * "UnsupportedAttributeConstraint".
+   */
+  val testUnsupportedAttributeConstraints = suite("testUnsupportedAttributeConstraints") {
+    // Examples taken from https://github.com/NCATSTranslator/ReasonerAPI/blob/1e0795a1c4ff5bcac3ccd5f188fdc09ec6bd27c3/ImplementationRules.md#specifying-permitted-and-excluded-kps-to-an-ara
+    val query = """{
+                     "message": {
+                       "query_graph": {
+                         "nodes": {
+                           "n0": {
+                             "categories": ["biolink:GeneOrGeneProduct"]
+                           },
+                           "n1": { "categories": ["biolink:AnatomicalEntity"], "ids": ["GO:0005634"] }
+                         },
+                         "edges": {
+                           "e0": {
+                             "subject": "n0",
+                             "object": "n1",
+                             "predicates": ["biolink:part_of"],
+                             "attribute_constraints": [{
+                               "id": "biolink:knowledge_source",
+                               "name": "knowledge source",
+                               "value": "infores:semmeddb",
+                               "not": true,
+                               "operator": "=="
+                             }]
+                           }
+                         }
+                       }
+                     }
+                   }"""
+
+    testM("test unsupported attribute constraint") {
+      for {
+        biolinkData <- biolinkData
+
+        server <- Server.httpApp
+        response <- server(
+          Request(
+            method = Method.POST,
+            uri = Uri.unsafeFromString("/query")
+          )
+            .withHeaders(Accept(MediaType.application.json), `Content-Type`(MediaType.application.json))
+            .withEntity(query)
+        )
+        content <- EntityDecoder.decodeText(response)
+        trapiResponseJson <- ZIO.fromEither(io.circe.parser.parse(content))
+
+        trapiResponse <- ZIO.fromEither(
+          {
+            implicit val decoderIRI: Decoder[IRI] = Implicits.iriDecoder(biolinkData.prefixes)
+            implicit val keyDecoderIRI: KeyDecoder[IRI] = Implicits.iriKeyDecoder(biolinkData.prefixes)
+            implicit val decoderBiolinkClass: Decoder[BiolinkClass] = Implicits.biolinkClassDecoder(biolinkData.classes)
+            implicit val decoderBiolinkPredicate: Decoder[BiolinkPredicate] =
+              Implicits.biolinkPredicateDecoder(biolinkData.predicates)
+            implicit lazy val decoderTRAPIAttribute: Decoder[TRAPIAttribute] = deriveDecoder[TRAPIAttribute]
+
+            trapiResponseJson.as[TRAPIResponse]
+          }
+        )
+
+        logs = trapiResponse.logs
+        logsWithUnsupportedAttributeConstraint = logs.getOrElse(List()).filter({
+          case LogEntry(_, Some("Error"), Some("UnsupportedAttributeConstraint"), _) => true
+          case _ => false
+        })
+      } yield assert(response.status)(Assertion.hasField("isSuccess", _.isSuccess, Assertion.isTrue)) &&
+        assert(content)(Assertion.isNonEmptyString) &&
+        // Should return an UnsupportedAttributeConstraint as the status ...
+        assert(trapiResponse.status)(Assertion.isSome(Assertion.equalTo("UnsupportedAttributeConstraint"))) &&
+        // ... and in the logs.
+        assert(logs)(Assertion.isSome(Assertion.isNonEmpty)) &&
+        assert(logsWithUnsupportedAttributeConstraint)(Assertion.isNonEmpty)
+    }
+  }
+
+  /**
+   * If CAM-KP-API receives a qualifier constraint that it does not support, it MUST return an empty response (since no
+   * edges meet the constraint).
+   *
+   * (This is still in development at https://github.com/NCATSTranslator/ReasonerAPI/pull/364)
+   */
+  val testUnsupportedQualifierConstraints = suite("testUnsupportedConstraints") {
+    // Examples taken from https://github.com/NCATSTranslator/ReasonerAPI/blob/7520ac564e63289dffe092d4c7affd6db4ba22f1/examples/Message/subject_and_object_qualifiers.json
+    val query = """{
+                     "message": {
+                       "query_graph": {
+                         "nodes": {
+                           "n0": {
+                             "categories": ["biolink:GeneOrGeneProduct"]
+                           },
+                           "n1": { "categories": ["biolink:AnatomicalEntity"], "ids": ["GO:0005634"] }
+                         },
+                         "edges": {
+                           "e0": {
+                             "subject": "n0",
+                             "object": "n1",
+                             "predicates": ["biolink:part_of"],
+                             "qualifier_constraints": [{
+                               "qualifier_set": [{
+                                 "qualifier_type_id": "biolink:subject_aspect_qualifier",
+                                 "qualifier_value": "abundance"
+                               }, {
+                                 "qualifier_type_id": "biolink:subject_direction_qualifier",
+                                 "qualifier_value": "decreased"
+                               }]
+                             }]
+                           }
+                         }
+                       }
+                     }
+                   }"""
+
+
+    testM("test unsupported qualifier constraint on QEdge") {
+      for {
+        biolinkData <- biolinkData
+
+        server <- Server.httpApp
+        response <- server(
+          Request(
+            method = Method.POST,
+            uri = Uri.unsafeFromString("/query")
+          )
+            .withHeaders(Accept(MediaType.application.json), `Content-Type`(MediaType.application.json))
+            .withEntity(query)
+        )
+        content <- EntityDecoder.decodeText(response)
+        trapiResponseJson <- ZIO.fromEither(io.circe.parser.parse(content))
+
+        trapiResponse <- ZIO.fromEither(
+          {
+            implicit val decoderIRI: Decoder[IRI] = Implicits.iriDecoder(biolinkData.prefixes)
+            implicit val keyDecoderIRI: KeyDecoder[IRI] = Implicits.iriKeyDecoder(biolinkData.prefixes)
+            implicit val decoderBiolinkClass: Decoder[BiolinkClass] = Implicits.biolinkClassDecoder(biolinkData.classes)
+            implicit val decoderBiolinkPredicate: Decoder[BiolinkPredicate] =
+              Implicits.biolinkPredicateDecoder(biolinkData.predicates)
+            implicit lazy val decoderTRAPIAttribute: Decoder[TRAPIAttribute] = deriveDecoder[TRAPIAttribute]
+
+            trapiResponseJson.as[TRAPIResponse]
+          }
+        )
+
+        logs = trapiResponse.logs
+        logWarningOfQualifierConstraints = logs.getOrElse(List()).filter({
+          // We've made this up ourselves.
+          case LogEntry(_, Some("Warning"), Some("UnsupportedQualifierConstraint"), _) => true
+          case _ => false
+        })
+      } yield assert(response.status)(Assertion.hasField("isSuccess", _.isSuccess, Assertion.isTrue)) &&
+        assert(content)(Assertion.isNonEmptyString) &&
+        // Should return an overall status of Success
+        assert(trapiResponse.status)(Assertion.isSome(Assertion.equalTo("Success"))) &&
+        // ... and in the logs
+        assert(logs)(Assertion.isSome(Assertion.isNonEmpty)) &&
+        assert(logWarningOfQualifierConstraints)(Assertion.isNonEmpty) &&
+        // ... and with no results.
+        assert(trapiResponse.message.results)(Assertion.isSome(Assertion.isEmpty))
+    }
+  }
 
   /** This query contains two unexpected properties:
     *   - unknown_qnode_property on the "n0" QNode
@@ -86,7 +248,9 @@ object TRAPITest extends DefaultRunnableSpec with LazyLogging {
   val testLayer = HttpClient.makeHttpClientLayer ++ Biolink.makeUtilitiesLayer ++ configLayer >+> SPARQLQueryExecutor.makeCache.toLayer
 
   def spec = suite("TRAPI tests")(
-    testUnexpectedPropertiesOnQNodeAndQEdge
+    testUnexpectedPropertiesOnQNodeAndQEdge,
+    testUnsupportedAttributeConstraints,
+    testUnsupportedQualifierConstraints
   ).provideCustomLayer(testLayer.mapError(TestFailure.die))
 
 }


### PR DESCRIPTION
This PR adds TRAPI Tests to ensure that CAM-KP-API responds correctly to:
- An attribute constraint it does not understand
- A qualifier constraint it does not understand (as per PR https://github.com/NCATSTranslator/ReasonerAPI/pull/364)

Closes #565