### PR TITLE
Add mainClass to build.sbt and 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,9 +24,9 @@ run / mainClass := Some("org.renci.cam.Server")
 
 Compile / packageDoc / publishArtifact := false
 
-// Note that javaOptions will be ignored during tests if Test.fork = True
+// Fork Java during testing with the specified options.
 Test / fork := true
-javaOptions += "-Xmx8G"
+Test / javaOptions += "-Xmx8G"
 
 configs(IntegrationTest)
 Defaults.itSettings

--- a/build.sbt
+++ b/build.sbt
@@ -16,12 +16,17 @@ scalaVersion := "2.13.8"
 
 scalacOptions := Seq("-unchecked", "-deprecation", "-encoding", "utf8")
 
-javaOptions += "-Xmx8G"
-
 testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework")
 
+// Set the mainClass to org.renci.cam.Server so we start the Server by default.
+Compile / mainClass := Some("org.renci.cam.Server")
+run / mainClass := Some("org.renci.cam.Server")
+
 Compile / packageDoc / publishArtifact := false
+
+// Note that javaOptions will be ignored during tests if Test.fork = True
 Test / fork := true
+javaOptions += "-Xmx8G"
 
 configs(IntegrationTest)
 Defaults.itSettings


### PR DESCRIPTION
Adding mainClass to build.sbt allows us to run the server by running `sbt run`, and still allows us to run `sbt "runMain org.renci.cam.util.UpdateBiolinkResources"` if we need to update Biolink resources.

Also changes `javaOptions` to only apply during `Test`, which is the only case in which we fork (as per the [sbt documentation](https://www.scala-sbt.org/release/docs/Forking.html)).